### PR TITLE
ATL-2103: Fixed License Identifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 // This space intentionally left blank

--- a/lib/design_tokens.dart
+++ b/lib/design_tokens.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 export 'src/core_tokens/color_primitive.dart';

--- a/lib/src/core_tokens/color_primitive.dart
+++ b/lib/src/core_tokens/color_primitive.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/core_tokens/radius_primitive.dart
+++ b/lib/src/core_tokens/radius_primitive.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/core_tokens/spacing_primitive.dart
+++ b/lib/src/core_tokens/spacing_primitive.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 class SpacingPrimitive {

--- a/lib/src/core_tokens/typography_primitive.dart
+++ b/lib/src/core_tokens/typography_primitive.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/base/color/background/background_base.dart
+++ b/lib/src/webos_tokens/base/color/background/background_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'full/full_base.dart';

--- a/lib/src/webos_tokens/base/color/background/full/full_base.dart
+++ b/lib/src/webos_tokens/base/color/background/full/full_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/base/color/background/overlay/overlay_base.dart
+++ b/lib/src/webos_tokens/base/color/background/overlay/overlay_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/base/color/background/popup/popup_base.dart
+++ b/lib/src/webos_tokens/base/color/background/popup/popup_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/base/color/on_background/on_background_base.dart
+++ b/lib/src/webos_tokens/base/color/on_background/on_background_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/base/color/on_background/popup/popup_base.dart
+++ b/lib/src/webos_tokens/base/color/on_background/popup/popup_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/base/color/on_surface/on_surface_base.dart
+++ b/lib/src/webos_tokens/base/color/on_surface/on_surface_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/base/color/on_surface/overlay/overlay_base.dart
+++ b/lib/src/webos_tokens/base/color/on_surface/overlay/overlay_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/base/color/on_surface/popup/popup_base.dart
+++ b/lib/src/webos_tokens/base/color/on_surface/popup/popup_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/base/color/scrim/scrim_base.dart
+++ b/lib/src/webos_tokens/base/color/scrim/scrim_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/base/color/stroke/overlay/overlay_base.dart
+++ b/lib/src/webos_tokens/base/color/stroke/overlay/overlay_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/base/color/stroke/popup/popup_base.dart
+++ b/lib/src/webos_tokens/base/color/stroke/popup/popup_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/base/color/stroke/stroke_base.dart
+++ b/lib/src/webos_tokens/base/color/stroke/stroke_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/base/color/surface/overlay/overlay_base.dart
+++ b/lib/src/webos_tokens/base/color/surface/overlay/overlay_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/base/color/surface/popup/popup_base.dart
+++ b/lib/src/webos_tokens/base/color/surface/popup/popup_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/base/color/surface/surface_base.dart
+++ b/lib/src/webos_tokens/base/color/surface/surface_base.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/color_semantic.dart
+++ b/lib/src/webos_tokens/color_semantic.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'base/color/background/background_base.dart';

--- a/lib/src/webos_tokens/dark/color/background/background.dart
+++ b/lib/src/webos_tokens/dark/color/background/background.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import '../../../base/color/background/background_base.dart';

--- a/lib/src/webos_tokens/dark/color/background/full/full.dart
+++ b/lib/src/webos_tokens/dark/color/background/full/full.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/dark/color/background/overlay/overlay.dart
+++ b/lib/src/webos_tokens/dark/color/background/overlay/overlay.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/dark/color/background/popup/popup.dart
+++ b/lib/src/webos_tokens/dark/color/background/popup/popup.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/dark/color/color_semantic_dark.dart
+++ b/lib/src/webos_tokens/dark/color/color_semantic_dark.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import '../../color_semantic.dart';

--- a/lib/src/webos_tokens/dark/color/on_background/on_background.dart
+++ b/lib/src/webos_tokens/dark/color/on_background/on_background.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/dark/color/on_background/popup/popup.dart
+++ b/lib/src/webos_tokens/dark/color/on_background/popup/popup.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/dark/color/on_surface/on_surface.dart
+++ b/lib/src/webos_tokens/dark/color/on_surface/on_surface.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart' show Color;

--- a/lib/src/webos_tokens/dark/color/on_surface/overlay/overlay.dart
+++ b/lib/src/webos_tokens/dark/color/on_surface/overlay/overlay.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/dark/color/on_surface/popup/popup.dart
+++ b/lib/src/webos_tokens/dark/color/on_surface/popup/popup.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/dark/color/scrim/scrim.dart
+++ b/lib/src/webos_tokens/dark/color/scrim/scrim.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/dark/color/stroke/overlay/overlay.dart
+++ b/lib/src/webos_tokens/dark/color/stroke/overlay/overlay.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/dark/color/stroke/popup/popup.dart
+++ b/lib/src/webos_tokens/dark/color/stroke/popup/popup.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/dark/color/stroke/stroke.dart
+++ b/lib/src/webos_tokens/dark/color/stroke/stroke.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart' show Color;

--- a/lib/src/webos_tokens/dark/color/surface/overlay/overlay.dart
+++ b/lib/src/webos_tokens/dark/color/surface/overlay/overlay.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/dark/color/surface/popup/popup.dart
+++ b/lib/src/webos_tokens/dark/color/surface/popup/popup.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/dark/color/surface/surface.dart
+++ b/lib/src/webos_tokens/dark/color/surface/surface.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart' show Color;

--- a/lib/src/webos_tokens/light/color/background/background.dart
+++ b/lib/src/webos_tokens/light/color/background/background.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import '../../../base/color/background/background_base.dart';

--- a/lib/src/webos_tokens/light/color/background/full/full.dart
+++ b/lib/src/webos_tokens/light/color/background/full/full.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/light/color/background/overlay/overlay.dart
+++ b/lib/src/webos_tokens/light/color/background/overlay/overlay.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/light/color/background/popup/popup.dart
+++ b/lib/src/webos_tokens/light/color/background/popup/popup.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/light/color/color_semantic_light.dart
+++ b/lib/src/webos_tokens/light/color/color_semantic_light.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import '../../color_semantic.dart';

--- a/lib/src/webos_tokens/light/color/on_background/on_background.dart
+++ b/lib/src/webos_tokens/light/color/on_background/on_background.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/light/color/on_background/popup/popup.dart
+++ b/lib/src/webos_tokens/light/color/on_background/popup/popup.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/light/color/on_surface/on_surface.dart
+++ b/lib/src/webos_tokens/light/color/on_surface/on_surface.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart' show Color;

--- a/lib/src/webos_tokens/light/color/on_surface/overlay/overlay.dart
+++ b/lib/src/webos_tokens/light/color/on_surface/overlay/overlay.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/light/color/on_surface/popup/popup.dart
+++ b/lib/src/webos_tokens/light/color/on_surface/popup/popup.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/light/color/scrim/scrim.dart
+++ b/lib/src/webos_tokens/light/color/scrim/scrim.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/light/color/stroke/overlay/overlay.dart
+++ b/lib/src/webos_tokens/light/color/stroke/overlay/overlay.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/light/color/stroke/popup/popup.dart
+++ b/lib/src/webos_tokens/light/color/stroke/popup/popup.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/light/color/stroke/stroke.dart
+++ b/lib/src/webos_tokens/light/color/stroke/stroke.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart' show Color;

--- a/lib/src/webos_tokens/light/color/surface/overlay/overlay.dart
+++ b/lib/src/webos_tokens/light/color/surface/overlay/overlay.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/light/color/surface/popup/popup.dart
+++ b/lib/src/webos_tokens/light/color/surface/popup/popup.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/webos_tokens/light/color/surface/surface.dart
+++ b/lib/src/webos_tokens/light/color/surface/surface.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart' show Color;

--- a/lib/src/webos_tokens/radius_semantic.dart
+++ b/lib/src/webos_tokens/radius_semantic.dart
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import 'package:flutter/material.dart';

--- a/packages/core-tokens/css/color-primitive.css
+++ b/packages/core-tokens/css/color-primitive.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
  
 /* color-primitive.css */

--- a/packages/core-tokens/css/radius-primitive.css
+++ b/packages/core-tokens/css/radius-primitive.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /* radius-primitive.css */

--- a/packages/core-tokens/css/spacing-primitive.css
+++ b/packages/core-tokens/css/spacing-primitive.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /* spacing-primitive.css */

--- a/packages/core-tokens/css/typography-primitive.css
+++ b/packages/core-tokens/css/typography-primitive.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /* typography-primitive.css */

--- a/packages/core-tokens/index.js
+++ b/packages/core-tokens/index.js
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 // This space intentionally left blank

--- a/packages/mobile-tokens/css/color-semantic-lg-brand.css
+++ b/packages/mobile-tokens/css/color-semantic-lg-brand.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 @import "@enovaui/core-tokens/css/color-primitive.css";

--- a/packages/mobile-tokens/css/color-semantic-mobile.css
+++ b/packages/mobile-tokens/css/color-semantic-mobile.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 @import "@enovaui/core-tokens/css/color-primitive.css";

--- a/packages/mobile-tokens/css/color-semantic-mono-black.css
+++ b/packages/mobile-tokens/css/color-semantic-mono-black.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 @import "@enovaui/core-tokens/css/color-primitive.css";

--- a/packages/mobile-tokens/css/color-semantic-mono-white.css
+++ b/packages/mobile-tokens/css/color-semantic-mono-white.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 @import "@enovaui/core-tokens/css/color-primitive.css";

--- a/packages/mobile-tokens/css/color-semantic-web.css
+++ b/packages/mobile-tokens/css/color-semantic-web.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 @import "@enovaui/core-tokens/css/color-primitive.css";

--- a/packages/mobile-tokens/index.js
+++ b/packages/mobile-tokens/index.js
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 // This space intentionally left blank

--- a/packages/web-tokens/css/color-semantic-lg-brand.css
+++ b/packages/web-tokens/css/color-semantic-lg-brand.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 @import "@enovaui/core-tokens/css/color-primitive.css";

--- a/packages/web-tokens/css/color-semantic-mobile.css
+++ b/packages/web-tokens/css/color-semantic-mobile.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 @import "@enovaui/core-tokens/css/color-primitive.css";

--- a/packages/web-tokens/css/color-semantic-mono-black.css
+++ b/packages/web-tokens/css/color-semantic-mono-black.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
  @import "@enovaui/core-tokens/css/color-primitive.css";

--- a/packages/web-tokens/css/color-semantic-mono-white.css
+++ b/packages/web-tokens/css/color-semantic-mono-white.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
  @import "@enovaui/core-tokens/css/color-primitive.css";

--- a/packages/web-tokens/css/color-semantic-web.css
+++ b/packages/web-tokens/css/color-semantic-web.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 @import "@enovaui/core-tokens/css/color-primitive.css";

--- a/packages/web-tokens/index.js
+++ b/packages/web-tokens/index.js
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 // This space intentionally left blank

--- a/packages/webos-tokens/css/color-semantic-dark.css
+++ b/packages/webos-tokens/css/color-semantic-dark.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 @import "@enovaui/core-tokens/css/color-primitive.css";

--- a/packages/webos-tokens/css/color-semantic-light.css
+++ b/packages/webos-tokens/css/color-semantic-light.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 @import "@enovaui/core-tokens/css/color-primitive.css";

--- a/packages/webos-tokens/css/radius-semantic.css
+++ b/packages/webos-tokens/css/radius-semantic.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 @import "@enovaui/core-tokens/css/radius-primitive.css";

--- a/packages/webos-tokens/index.js
+++ b/packages/webos-tokens/index.js
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2025 LG Electronics Inc.
- * SPDX-License-Identifier: LicenseRef-LGE-Proprietary
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 // This space intentionally left blank


### PR DESCRIPTION
### Checklist

[//]: # (Contribution guide should be added)
* [ ] A CHANGELOG entry is included  
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
As we open sourced the repository, we have guided to update our License Identifier to Apache-2.0.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Replaced SPDX-License-Identifier: LicenseRef-LGE-Proprietary to SPDX-License-Identifier: Apache-2.0

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ATL-2103

### Comments
[//]: # (DCO should be here)
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)