### PR TITLE
ATL-3714: Correct dark theme color mappings

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -11,10 +11,10 @@ Dark theme color tokens: Updated incorrect color mappings in dark semantic color
 - `semantic_color_on_surface_input_field` value to `white` in dark semantic color
 - `semantic_color_on_surface_sub_focused` value to `neutral-gray-40` in dark semantic color
 - `semantic_color_on_surface_sub_selected` value to `neutral-gray-50` in dark semantic color
-- `semantic_color_surface_overlay_default` value to `cool-gray-15` in dark semantic color
-- `semantic_color_surface_overlay_default` value to `cool-gray-90` in light semantic color
 - `semantic_color_on_surface_overlay_main` value to `white` in dark semantic color
 - `semantic_color_on_surface_overlay_sub` value to `neutral-gray-70` in dark semantic color
+- `semantic_color_surface_overlay_default` value to `cool-gray-15` in dark semantic color
+- `semantic_color_surface_overlay_default` value to `cool-gray-90` in light semantic color
 
 ## [0.8.0] - 2025-07-14
 

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -8,9 +8,13 @@ The following is a curated list of changes in the flutter tokens module, newest 
 
 Dark theme color tokens: Updated incorrect color mappings in dark semantic color tokens
 
-- onSurface.inputField: neutral-gray-10 → white
-- onSurface.subFocused: cool-gray-30 → neutral-gray-40
-- onSurface.subSelected: white → neutral-gray-50
+- `semantic_color_on_surface_input_field` value to `white` in dark semantic color
+- `semantic_color_on_surface_sub_focused` value to `neutral-gray-40` in dark semantic color
+- `semantic_color_on_surface_sub_selected` value to `neutral-gray-50` in dark semantic color
+- `semantic_color_surface_overlay_default` value to `cool-gray-15` in dark semantic color
+- `semantic_color_surface_overlay_default` value to `cool-gray-90` in light semantic color
+- `semantic_color_on_surface_overlay_main` value to `white` in dark semantic color
+- `semantic_color_on_surface_overlay_sub` value to `neutral-gray-70` in dark semantic color
 
 ## [0.8.0] - 2025-07-14
 

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The following is a curated list of changes in the flutter tokens module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+Dark theme color tokens: Updated incorrect color mappings in dark semantic color tokens
+
+- onSurface.inputField: neutral-gray-10 → white
+- onSurface.subFocused: cool-gray-30 → neutral-gray-40
+- onSurface.subSelected: white → neutral-gray-50
+
 ## [0.8.0] - 2025-07-14
 
 ### Added

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -6,8 +6,6 @@ The following is a curated list of changes in the flutter tokens module, newest 
 
 ### Changed
 
-Dark theme color tokens: Updated incorrect color mappings in dark semantic color tokens
-
 - `semantic_color_on_surface_input_field` value to `white` in dark semantic color
 - `semantic_color_on_surface_sub_focused` value to `neutral-gray-40` in dark semantic color
 - `semantic_color_on_surface_sub_selected` value to `neutral-gray-50` in dark semantic color

--- a/lib/src/webos_tokens/dark/color/on_surface/on_surface.dart
+++ b/lib/src/webos_tokens/dark/color/on_surface/on_surface.dart
@@ -28,9 +28,9 @@ class OnSurface extends OnSurfaceBase {
   @override
   Color get sub => ColorPrimitive.instance.neutralGray70;
   @override
-  Color get subFocused => ColorPrimitive.instance.coolGray30;
+  Color get subFocused => ColorPrimitive.instance.neutralGray40;
   @override
-  Color get subSelected => ColorPrimitive.instance.white;
+  Color get subSelected => ColorPrimitive.instance.neutralGray50;
   @override
   Color get accent => ColorPrimitive.instance.activeRed55;
   @override
@@ -38,7 +38,7 @@ class OnSurface extends OnSurfaceBase {
   @override
   Color get highlightYellow => ColorPrimitive.instance.yellow80;
   @override
-  Color get inputField => ColorPrimitive.instance.neutralGray10;
+  Color get inputField => ColorPrimitive.instance.white;
   @override
   Color get white => ColorPrimitive.instance.white;
   @override

--- a/lib/src/webos_tokens/dark/color/on_surface/overlay/overlay.dart
+++ b/lib/src/webos_tokens/dark/color/on_surface/overlay/overlay.dart
@@ -12,7 +12,7 @@ class Overlay extends OverlayBase {
   const Overlay();
 
   @override
-  Color get main => ColorPrimitive.instance.neutralGray10;
+  Color get main => ColorPrimitive.instance.white;
   @override
-  Color get sub => ColorPrimitive.instance.neutralGray35;
+  Color get sub => ColorPrimitive.instance.neutralGray70;
 }

--- a/lib/src/webos_tokens/dark/color/surface/overlay/overlay.dart
+++ b/lib/src/webos_tokens/dark/color/surface/overlay/overlay.dart
@@ -12,5 +12,5 @@ class Overlay extends OverlayBase {
   const Overlay();
 
   @override
-  Color get defaultColor => ColorPrimitive.instance.coolGray55;
+  Color get defaultColor => ColorPrimitive.instance.coolGray15;
 }

--- a/lib/src/webos_tokens/light/color/surface/overlay/overlay.dart
+++ b/lib/src/webos_tokens/light/color/surface/overlay/overlay.dart
@@ -12,5 +12,5 @@ class Overlay extends OverlayBase {
   const Overlay();
 
   @override
-  Color get defaultColor => ColorPrimitive.instance.coolGray55;
+  Color get defaultColor => ColorPrimitive.instance.coolGray90;
 }


### PR DESCRIPTION
### Checklist

[//]: # (Contribution guide should be added)
* [x] A CHANGELOG entry is included  
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Fixed incorrect color token values in semantic color tokens that were not aligned with the JSON schema definitions. The Dart files contained mismatched color values compared to the color-semantic-dark.json file, which could cause visual inconsistencies in dark theme implementations.


### Resolution
Code Status: The code now correctly maps all dark semantic color tokens to their intended values as defined in the JSON schema.

**Impact**: This change ensures that:
- Theme color tokens are consistent across JSON definitions and Dart implementations
- Visual rendering will match the intended design specifications
- Future color token updates will be properly synchronized

**Why**: The color token values were manually generated/parsed and contained errors in the mapping process. This fix ensures design system consistency and prevents potential UI inconsistencies.



### Additional Considerations
**Testing**:
- Verify that dark theme components render with correct colors
- Test affected UI components that use on.surface color tokens
- Ensure no visual regressions in existing dark theme implementations

**Outstanding Questions**: None

**Side Effects**:
- This is a bug fix with no breaking changes
- Existing code using these color tokens will now display the correct colors
- No migration steps required for consumers


### Links
[ATL-3714](http://jira.lge.com/issue/browse/ATL-3714)


### Comments
Correct mismatched color values in semantic color tokens to align with JSON definitions
- Fix on.surface.input-field from neutral-gray-10 to white in dark semantic color
- Fix on.surface.sub-focused from cool-gray-30 to neutral-gray-40 in dark semantic color
- Fix on.surface.sub-selected from white to neutral-gray-50 in dark semantic color
- Fix on.surface.overlay.main from neutral-gray-10 to white in dark semantic color
- Fix on.surface.overlay.sub from neutral-gray-35 to neutral-gray-70 in dark semantic color
- Fix surface.overlay.default from cool-gray-55 to cool-gray-15 in dark semantic color
- Fix surface.overlay.default from cool-gray-55 to cool-gray-90 in light semantic color
