### PR TITLE
ATL-19419: Changed webos-tokens's semantic radius values

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 The following is a curated list of changes in the flutter tokens module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `semantic_raidus_button` value to `primitive_radius_36`
+- `semantic_radius_container` value to `primitive_radius_60`
+- `semantic_radius_popup` value to `primitive_radius_108`
+- `semantic_radius_overlay` value to `primitive_radius_108`
+
 ## [1.0.0] - 2026-04-29
 
 ### Added

--- a/lib/src/webos_tokens/radius_semantic.dart
+++ b/lib/src/webos_tokens/radius_semantic.dart
@@ -11,8 +11,8 @@ class RadiusSemantic {
   const RadiusSemantic();
 
   Radius get full => RadiusPrimitive.instance.radius999;
-  Radius get button => RadiusPrimitive.instance.radius24;
-  Radius get container => RadiusPrimitive.instance.radius36;
-  Radius get overlay => RadiusPrimitive.instance.radius60;
-  Radius get popup => RadiusPrimitive.instance.radius60;
+  Radius get button => RadiusPrimitive.instance.radius36;
+  Radius get container => RadiusPrimitive.instance.radius60;
+  Radius get overlay => RadiusPrimitive.instance.radius108;
+  Radius get popup => RadiusPrimitive.instance.radius108;
 }

--- a/packages/webos-tokens/CHANGELOG.md
+++ b/packages/webos-tokens/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 The following is a curated list of changes in the webos tokens module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `semantic-raidus-button` value to `primitive-radius-36`
+- `semantic-radius-container` value to `primitive-radius-60`
+- `semantic-radius-popup` value to `primitive-radius-108`
+- `semantic-radius-overlay` value to `primitive-radius-108`
+
 ## [1.0.0] - 2026-04-29
 
 - No significant changes

--- a/packages/webos-tokens/css/radius-semantic.css
+++ b/packages/webos-tokens/css/radius-semantic.css
@@ -11,8 +11,8 @@ Semantic Radius Tokens
 
 :root {
 	--semantic-radius-full: var(--primitive-radius-999);
-	--semantic-radius-button: var(--primitive-radius-24);
-	--semantic-radius-container: var(--primitive-radius-36);
-	--semantic-radius-overlay: var(--primitive-radius-60);
-	--semantic-radius-popup: var(--primitive-radius-60);
+	--semantic-radius-button: var(--primitive-radius-36);
+	--semantic-radius-container: var(--primitive-radius-60);
+	--semantic-radius-overlay: var(--primitive-radius-108);
+	--semantic-radius-popup: var(--primitive-radius-108);
 }

--- a/packages/webos-tokens/json/radius-semantic.json
+++ b/packages/webos-tokens/json/radius-semantic.json
@@ -2,10 +2,10 @@
     "semantic": {
         "radius": {
             "full": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
-            "button": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-24"},
-            "container": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"},
-            "overlay": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-60"},
-            "popup": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-60"}
+            "button": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"},
+            "container": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-60"},
+            "overlay": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-108"},
+            "popup": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-108"}
         }
     }
 }


### PR DESCRIPTION
### Checklist

[//]: # (Contribution guide should be added)
* [x] A CHANGELOG entry is included  
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
This pull request updates the semantic radius tokens across the Flutter and WebOS tokens modules to use larger, more consistent primitive radius values. The changes ensure that the semantic values for button, container, overlay, and popup radii now reference updated primitive values in all relevant files.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
**webOS tokens's Semantic radius value updates:**

- `semantic-raidus-button` value to `primitive-radius-36`
- `semantic-radius-container` value to `primitive-radius-60`
- `semantic-radius-popup` value to `primitive-radius-108`
- `semantic-radius-overlay` value to `primitive-radius-108`

* Updated the `button`, `container`, `overlay`, and `popup` semantic radius tokens to reference larger primitive radius values in the following files:
  - Dart source (`lib/src/webos_tokens/radius_semantic.dart`)
  - CSS tokens (`packages/webos-tokens/css/radius-semantic.css`)
  - JSON tokens (`packages/webos-tokens/json/radius-semantic.json`)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
[//]: # (DCO should be here)
