### PR TITLE
ATL-21601: Update default handle color to white in semantic color tokens

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the flutter tokens module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `semantic_color_surface_default_handle` value to `white`
+
 ## [2.0.0] - 2026-04-30
 
 ### Changed

--- a/lib/src/webos_tokens/dark/color/surface/surface.dart
+++ b/lib/src/webos_tokens/dark/color/surface/surface.dart
@@ -28,7 +28,7 @@ class Surface extends SurfaceBase {
   @override
   Color get defaultGroup => ColorPrimitive.instance.white;
   @override
-  Color get defaultHandle => ColorPrimitive.instance.activeRed70;
+  Color get defaultHandle => ColorPrimitive.instance.white;
   @override
   Color get defaultIndicator => ColorPrimitive.instance.white;
   @override

--- a/lib/src/webos_tokens/high_contrast/color/surface/surface.dart
+++ b/lib/src/webos_tokens/high_contrast/color/surface/surface.dart
@@ -28,7 +28,7 @@ class Surface extends SurfaceBase {
   @override
   Color get defaultGroup => ColorPrimitive.instance.white;
   @override
-  Color get defaultHandle => ColorPrimitive.instance.activeRed70;
+  Color get defaultHandle => ColorPrimitive.instance.white;
   @override
   Color get defaultIndicator => ColorPrimitive.instance.white;
   @override

--- a/lib/src/webos_tokens/light/color/surface/surface.dart
+++ b/lib/src/webos_tokens/light/color/surface/surface.dart
@@ -28,7 +28,7 @@ class Surface extends SurfaceBase {
   @override
   Color get defaultGroup => ColorPrimitive.instance.neutralGray50;
   @override
-  Color get defaultHandle => ColorPrimitive.instance.activeRed70;
+  Color get defaultHandle => ColorPrimitive.instance.white;
   @override
   Color get defaultIndicator => ColorPrimitive.instance.neutralGray10;
   @override

--- a/packages/webos-tokens/CHANGELOG.md
+++ b/packages/webos-tokens/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the webos tokens module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `semantic-color-surface-default-handle` value to `white`
+
 ## [2.0.0] - 2026-04-30
 
 ### Changed

--- a/packages/webos-tokens/css/color-semantic-dark.css
+++ b/packages/webos-tokens/css/color-semantic-dark.css
@@ -36,7 +36,7 @@ Semantic Color Tokens
 	--semantic-color-surface-default-selected: var(--primitive-color-cool-gray-10);
 	--semantic-color-surface-default-disabled-focused: var(--primitive-color-neutral-gray-70);
 	--semantic-color-surface-default-group: var(--primitive-color-white);
-	--semantic-color-surface-default-handle: var(--primitive-color-active-red-70);
+	--semantic-color-surface-default-handle: var(--primitive-color-white);
 	--semantic-color-surface-default-indicator: var(--primitive-color-white);
 	--semantic-color-surface-default-notification: var(--primitive-color-deep-orange-50);
 	--semantic-color-surface-default-placeholder: var(--primitive-color-cool-gray-10);

--- a/packages/webos-tokens/css/color-semantic-high-contrast.css
+++ b/packages/webos-tokens/css/color-semantic-high-contrast.css
@@ -36,7 +36,7 @@ Semantic Color Tokens
 	--semantic-color-surface-default-selected: var(--primitive-color-cool-gray-10);
 	--semantic-color-surface-default-disabled-focused: var(--primitive-color-neutral-gray-70);
 	--semantic-color-surface-default-group: var(--primitive-color-white);
-	--semantic-color-surface-default-handle: var(--primitive-color-active-red-70);
+	--semantic-color-surface-default-handle: var(--primitive-color-white);
 	--semantic-color-surface-default-indicator: var(--primitive-color-white);
 	--semantic-color-surface-default-notification: var(--primitive-color-deep-orange-50);
 	--semantic-color-surface-default-placeholder: var(--primitive-color-cool-gray-10);

--- a/packages/webos-tokens/css/color-semantic-light.css
+++ b/packages/webos-tokens/css/color-semantic-light.css
@@ -36,7 +36,7 @@ Semantic Color Tokens
 	--semantic-color-surface-default-selected: var(--primitive-color-cool-gray-40);
 	--semantic-color-surface-default-disabled-focused: var(--primitive-color-cool-gray-80);
 	--semantic-color-surface-default-group: var(--primitive-color-neutral-gray-50);
-	--semantic-color-surface-default-handle: var(--primitive-color-active-red-70);
+	--semantic-color-surface-default-handle: var(--primitive-color-white);
 	--semantic-color-surface-default-indicator: var(--primitive-color-neutral-gray-10);
 	--semantic-color-surface-default-notification: var(--primitive-color-deep-orange-50);
 	--semantic-color-surface-default-placeholder: var(--primitive-color-cool-gray-15);

--- a/packages/webos-tokens/json/color-semantic-dark.json
+++ b/packages/webos-tokens/json/color-semantic-dark.json
@@ -59,7 +59,7 @@
                 "default-selected": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cool-gray-10"},
                 "default-disabled-focused": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/neutral-gray-70"},
                 "default-group": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
-                "default-handle": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/active-red-70"},
+                "default-handle": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                 "default-indicator": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                 "default-notification": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/deep-orange-50"},
                 "default-placeholder": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cool-gray-10"},

--- a/packages/webos-tokens/json/color-semantic-high-contrast.json
+++ b/packages/webos-tokens/json/color-semantic-high-contrast.json
@@ -59,7 +59,7 @@
                 "default-selected": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cool-gray-10"},
                 "default-disabled-focused": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/neutral-gray-70"},
                 "default-group": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
-                "default-handle": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/active-red-70"},
+                "default-handle": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                 "default-indicator": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                 "default-notification": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/deep-orange-50"},
                 "default-placeholder": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cool-gray-10"},

--- a/packages/webos-tokens/json/color-semantic-light.json
+++ b/packages/webos-tokens/json/color-semantic-light.json
@@ -59,7 +59,7 @@
                 "default-selected": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cool-gray-40"},
                 "default-disabled-focused": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cool-gray-80"},
                 "default-group": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/neutral-gray-50"},
-                "default-handle": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/active-red-70"},
+                "default-handle": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                 "default-indicator": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/neutral-gray-10"},
                 "default-notification": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/deep-orange-50"},
                 "default-placeholder": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cool-gray-15"},


### PR DESCRIPTION
### Checklist

[//]: # (Contribution guide should be added)
* [x] A CHANGELOG entry is included  
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
This pull request updates the value of the `surface default handle` semantic color token across all themes (light, dark, and high contrast) in both the Flutter and webOS tokens modules. The `default handle` color has been changed from red (`activeRed70`) to white for consistency and improved accessibility. All relevant CSS, JSON, and Dart source files, as well as changelogs, have been updated accordingly.

**Semantic color token updates:**

* Changed the value of `semantic_color_surface_default_handle` and `semantic-color-surface-default-handle` from `activeRed70` to `white` in all themes (light, dark, high contrast) in both Flutter and webOS tokens modules.

**Documentation and changelog:**

* Updated `CHANGELOG.md` files in both `lib/` and `packages/webos-tokens/` to document the change to the `surface default handle` color token [[1]](diffhunk://#diff-651bb9fbf832d38113915eaf1ae8e7489541f9d17c118ba900c8525b29760431R5-R10) [[2]](diffhunk://#diff-63efc19606c055157c654202b659731c141eee3cef698b2c7eabcea8b9db09b8R5-R10).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ATL-21601

### Comments
[//]: # (DCO should be here)
Enovaui-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)