### PR TITLE
ATL-22376: Updated webos_m_tokens

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 The following is a curated list of changes in the flutter tokens module, newest changes on the top.
 
+## [unreleased]
+
+### Removed
+
+- `semantic_radius_navigation_m`
+
+### Changed
+
+- `semantic_color_surface_navigation_bar` to `semantic_color_surface_access_bar`
+- `semantic_color_surface_navigation_bar_app_gradient_start` to `semantic_color_surface_access_bar_app_gradient_start`
+- `semantic_color_surface_navigation_bar_app_gradient_end` to `semantic_color_surface_access_bar_app_gradient_end`
+- `semantic_color_on_surface_navigation_bar_handle_dark` to `semantic_color_on_surface_access_bar_handle_dark` 
+- `semantic_color_on_surface_navigation_bar_handle_light` to `semantic_color_on_surface_access_bar_handle_light`
+- `semantic_color_stroke_navigation_bar` to `semantic_color_stroke_access_bar`
+- `semantic_color_stroke_navigation_bar_app` to `semantic_color_stroke_access_bar_app`
+
+### Added
+
+- `semantic_color_surface_button_notification`
+- `semantic_radius_access_bar_l` and `semantic_radius_access_bar_s`
+
 ## [3.1.0] - 2026-05-11
 
 ### Removed

--- a/lib/src/webos_m_tokens/base/color/on_surface/on_surface_base.dart
+++ b/lib/src/webos_m_tokens/base/color/on_surface/on_surface_base.dart
@@ -19,8 +19,8 @@ abstract class OnSurfaceBase {
   Color get accentLight;
   Color get accentLightDisabled;
   Color get black;
-  Color get navigationBarHandleDark;
-  Color get navigationBarHandleLight;
+  Color get accessBarHandleDark;
+  Color get accessBarHandleLight;
   Color get pageIndicatorDark;
   Color get pageIndicatorLight;
   Color get pickerPrimary;

--- a/lib/src/webos_m_tokens/base/color/stroke/stroke_base.dart
+++ b/lib/src/webos_m_tokens/base/color/stroke/stroke_base.dart
@@ -21,8 +21,8 @@ abstract class StrokeBase {
   Color get subSupporting;
   Color get accent;
   Color get accentDisabled;
-  Color get navigationBar;
-  Color get navigationBarApp;
+  Color get accessBar;
+  Color get accessBarApp;
   Color get pickerColor;
   Color get selectionInactive;
   Color get selectionInactiveDisabled;

--- a/lib/src/webos_m_tokens/base/color/surface/surface_base.dart
+++ b/lib/src/webos_m_tokens/base/color/surface/surface_base.dart
@@ -31,6 +31,7 @@ abstract class SurfaceBase {
   Color get buttonIcon;
   Color get buttonIconSelected;
   Color get buttonIconDisabled;
+  Color get buttonNotification;
   Color get chip;
   Color get chipSelected;
   Color get chipDisabled;
@@ -45,9 +46,9 @@ abstract class SurfaceBase {
   Color get listSelected;
   Color get menu;
   Color get menuSelected;
-  Color get navigationBar;
-  Color get navigationBarAppGradientStart;
-  Color get navigationBarAppGradientEnd;
+  Color get accessBar;
+  Color get accessBarAppGradientStart;
+  Color get accessBarAppGradientEnd;
   Color get pickerColor;
   Color get pickerDate;
   Color get sliderTickMark;

--- a/lib/src/webos_m_tokens/dark/color/on_surface/on_surface.dart
+++ b/lib/src/webos_m_tokens/dark/color/on_surface/on_surface.dart
@@ -34,6 +34,10 @@ class OnSurface extends OnSurfaceBase {
   @override
   Color get black => ColorPrimitive.instance.black;
   @override
+  Color get accessBarHandleDark => ColorPrimitive.instance.black;
+  @override
+  Color get accessBarHandleLight => ColorPrimitive.instance.white;
+  @override
   Color get pageIndicatorDark => ColorPrimitive.instance.black;
   @override
   Color get pageIndicatorLight => ColorPrimitive.instance.white;
@@ -47,8 +51,4 @@ class OnSurface extends OnSurfaceBase {
   Color get selectionCheckmarkActiveDisabled => ColorPrimitive.instance.sandGray55;
   @override
   Color get sliderHandle => ColorPrimitive.instance.cobaltBlue50;
-  @override
-  Color get accessBarHandleDark => ColorPrimitive.instance.black;
-  @override
-  Color get accessBarHandleLight => ColorPrimitive.instance.white;
 }

--- a/lib/src/webos_m_tokens/dark/color/on_surface/on_surface.dart
+++ b/lib/src/webos_m_tokens/dark/color/on_surface/on_surface.dart
@@ -34,10 +34,6 @@ class OnSurface extends OnSurfaceBase {
   @override
   Color get black => ColorPrimitive.instance.black;
   @override
-  Color get navigationBarHandleDark => ColorPrimitive.instance.black;
-  @override
-  Color get navigationBarHandleLight => ColorPrimitive.instance.white;
-  @override
   Color get pageIndicatorDark => ColorPrimitive.instance.black;
   @override
   Color get pageIndicatorLight => ColorPrimitive.instance.white;
@@ -51,4 +47,8 @@ class OnSurface extends OnSurfaceBase {
   Color get selectionCheckmarkActiveDisabled => ColorPrimitive.instance.sandGray55;
   @override
   Color get sliderHandle => ColorPrimitive.instance.cobaltBlue50;
+  @override
+  Color get accessBarHandleDark => ColorPrimitive.instance.black;
+  @override
+  Color get accessBarHandleLight => ColorPrimitive.instance.white;
 }

--- a/lib/src/webos_m_tokens/dark/color/stroke/stroke.dart
+++ b/lib/src/webos_m_tokens/dark/color/stroke/stroke.dart
@@ -38,10 +38,6 @@ class Stroke extends StrokeBase {
   @override
   Color get accentDisabled => ColorPrimitive.instance.cobaltBlue45;
   @override
-  Color get navigationBar => ColorPrimitive.instance.white;
-  @override
-  Color get navigationBarApp => ColorPrimitive.instance.white;
-  @override
   Color get pickerColor => ColorPrimitive.instance.sandGray55;
   @override
   Color get selectionInactive => ColorPrimitive.instance.sandGray55;
@@ -49,4 +45,8 @@ class Stroke extends StrokeBase {
   Color get selectionInactiveDisabled => ColorPrimitive.instance.sandGray55;
   @override
   Color get tabActive => ColorPrimitive.instance.activeRed55;
+  @override
+  Color get accessBar => ColorPrimitive.instance.white;
+  @override
+  Color get accessBarApp => ColorPrimitive.instance.white;
 }

--- a/lib/src/webos_m_tokens/dark/color/stroke/stroke.dart
+++ b/lib/src/webos_m_tokens/dark/color/stroke/stroke.dart
@@ -38,6 +38,10 @@ class Stroke extends StrokeBase {
   @override
   Color get accentDisabled => ColorPrimitive.instance.cobaltBlue45;
   @override
+  Color get accessBar => ColorPrimitive.instance.white;
+  @override
+  Color get accessBarApp => ColorPrimitive.instance.white;
+  @override
   Color get pickerColor => ColorPrimitive.instance.sandGray55;
   @override
   Color get selectionInactive => ColorPrimitive.instance.sandGray55;
@@ -45,8 +49,4 @@ class Stroke extends StrokeBase {
   Color get selectionInactiveDisabled => ColorPrimitive.instance.sandGray55;
   @override
   Color get tabActive => ColorPrimitive.instance.activeRed55;
-  @override
-  Color get accessBar => ColorPrimitive.instance.white;
-  @override
-  Color get accessBarApp => ColorPrimitive.instance.white;
 }

--- a/lib/src/webos_m_tokens/dark/color/surface/surface.dart
+++ b/lib/src/webos_m_tokens/dark/color/surface/surface.dart
@@ -86,12 +86,6 @@ class Surface extends SurfaceBase {
   @override
   Color get menuSelected => ColorPrimitive.instance.sandGray85;
   @override
-  Color get navigationBar => ColorPrimitive.instance.sandGray50;
-  @override
-  Color get navigationBarAppGradientStart => ColorPrimitive.instance.sandGray10;
-  @override
-  Color get navigationBarAppGradientEnd => ColorPrimitive.instance.sandGray25;
-  @override
   Color get pickerColor => ColorPrimitive.instance.white;
   @override
   Color get pickerDate => ColorPrimitive.instance.cobaltBlue45;
@@ -121,4 +115,12 @@ class Surface extends SurfaceBase {
   Color get toast => ColorPrimitive.instance.sandGray25;
   @override
   Color get tooltip => ColorPrimitive.instance.sandGray25;
+  @override
+  Color get buttonNotification => ColorPrimitive.instance.sandGray35;
+  @override
+  Color get accessBar => ColorPrimitive.instance.sandGray50;
+  @override
+  Color get accessBarAppGradientStart => ColorPrimitive.instance.sandGray10;
+  @override
+  Color get accessBarAppGradientEnd => ColorPrimitive.instance.sandGray25;
 }

--- a/lib/src/webos_m_tokens/dark/color/surface/surface.dart
+++ b/lib/src/webos_m_tokens/dark/color/surface/surface.dart
@@ -58,6 +58,8 @@ class Surface extends SurfaceBase {
   @override
   Color get buttonIconDisabled => ColorPrimitive.instance.sandGray30;
   @override
+  Color get buttonNotification => ColorPrimitive.instance.sandGray35;
+  @override
   Color get chip => ColorPrimitive.instance.sandGray30;
   @override
   Color get chipSelected => ColorPrimitive.instance.cobaltBlue40;
@@ -85,6 +87,12 @@ class Surface extends SurfaceBase {
   Color get menu => ColorPrimitive.instance.sandGray25;
   @override
   Color get menuSelected => ColorPrimitive.instance.sandGray85;
+  @override
+  Color get accessBar => ColorPrimitive.instance.sandGray50;
+  @override
+  Color get accessBarAppGradientStart => ColorPrimitive.instance.sandGray10;
+  @override
+  Color get accessBarAppGradientEnd => ColorPrimitive.instance.sandGray25;
   @override
   Color get pickerColor => ColorPrimitive.instance.white;
   @override
@@ -115,12 +123,4 @@ class Surface extends SurfaceBase {
   Color get toast => ColorPrimitive.instance.sandGray25;
   @override
   Color get tooltip => ColorPrimitive.instance.sandGray25;
-  @override
-  Color get buttonNotification => ColorPrimitive.instance.sandGray35;
-  @override
-  Color get accessBar => ColorPrimitive.instance.sandGray50;
-  @override
-  Color get accessBarAppGradientStart => ColorPrimitive.instance.sandGray10;
-  @override
-  Color get accessBarAppGradientEnd => ColorPrimitive.instance.sandGray25;
 }

--- a/lib/src/webos_m_tokens/radius_semantic.dart
+++ b/lib/src/webos_m_tokens/radius_semantic.dart
@@ -10,6 +10,8 @@ import '../core_tokens/radius_primitive.dart';
 class RadiusSemantic {
   const RadiusSemantic();
 
+  Radius get accessBarL => RadiusPrimitive.instance.radius48;
+  Radius get accessBarS => RadiusPrimitive.instance.radius40;
   Radius get appIconL => RadiusPrimitive.instance.radius36;
   Radius get appIconS => RadiusPrimitive.instance.radius28;
   Radius get badge => RadiusPrimitive.instance.radius999;
@@ -56,6 +58,4 @@ class RadiusSemantic {
   Radius get toast => RadiusPrimitive.instance.radius18;
   Radius get tooltip => RadiusPrimitive.instance.radius18;
   Radius get homeGridIndicator => RadiusPrimitive.instance.radius18;
-  Radius get accessBarL => RadiusPrimitive.instance.radius48;
-  Radius get accessBarS => RadiusPrimitive.instance.radius40;
 }

--- a/lib/src/webos_m_tokens/radius_semantic.dart
+++ b/lib/src/webos_m_tokens/radius_semantic.dart
@@ -29,7 +29,6 @@ class RadiusSemantic {
   Radius get menuM => RadiusPrimitive.instance.radius24;
   Radius get menuS => RadiusPrimitive.instance.radius18;
   Radius get navigationL => RadiusPrimitive.instance.radius48;
-  Radius get navigationM => RadiusPrimitive.instance.radius40;
   Radius get navigationS => RadiusPrimitive.instance.radius36;
   Radius get notificationCard => RadiusPrimitive.instance.radius36;
   Radius get ongoingBriefing => RadiusPrimitive.instance.radius30;
@@ -57,4 +56,6 @@ class RadiusSemantic {
   Radius get toast => RadiusPrimitive.instance.radius18;
   Radius get tooltip => RadiusPrimitive.instance.radius18;
   Radius get homeGridIndicator => RadiusPrimitive.instance.radius18;
+  Radius get accessBarL => RadiusPrimitive.instance.radius48;
+  Radius get accessBarS => RadiusPrimitive.instance.radius40;
 }

--- a/packages/webos-m-tokens/CHANGELOG.md
+++ b/packages/webos-m-tokens/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 The following is a curated list of changes in the webos tokens module, newest changes on the top.
 
+## [unreleased]
+
+### Removed
+
+- `semantic-radius-navigation-m`
+
+### Changed
+
+- `semantic-color-surface-navigation-bar` to `semantic-color-surface-access-bar`
+- `semantic-color-surface-navigation-bar-app-gradient-start` to `semantic-color-surface-access-bar-app-gradient-start`
+- `semantic-color-surface-navigation-bar-app-gradient-end` to `semantic-color-surface-access-bar-app-gradient-end`
+- `semantic-color-on-surface-navigation-bar-handle-dark` to `semantic-color-on-surface-access-bar-handle-dark`
+- `semantic-color-on-surface-navigation-bar-handle-light` to `semantic-color-on-surface-access-bar-handle-light`
+- `semantic-color-stroke-navigation-bar` to `semantic-color-stroke-access-bar`
+- `semantic-color-stroke-navigation-bar-app` to `semantic-color-stroke-access-bar-app`
+
+### Added
+
+- `semantic-color-surface-button-notification`
+- `semantic-radius-access-bar-l` and `semantic-radius-access-bar-s`
+
 ## [3.1.0] - 2026-05-11
 
 ### Removed

--- a/packages/webos-m-tokens/css/color-semantic-dark.css
+++ b/packages/webos-m-tokens/css/color-semantic-dark.css
@@ -67,9 +67,6 @@ Semantic Color Tokens
 	--semantic-color-surface-list-selected: var(--primitive-color-sand-gray-85);
 	--semantic-color-surface-menu: var(--primitive-color-sand-gray-25);
 	--semantic-color-surface-menu-selected: var(--primitive-color-sand-gray-85);
-	--semantic-color-surface-navigation-bar: var(--primitive-color-sand-gray-50);
-	--semantic-color-surface-navigation-bar-app-gradient-start: var(--primitive-color-sand-gray-10);
-	--semantic-color-surface-navigation-bar-app-gradient-end: var(--primitive-color-sand-gray-25);
 	--semantic-color-surface-picker-color: var(--primitive-color-white);
 	--semantic-color-surface-picker-date: var(--primitive-color-cobalt-blue-45);
 	--semantic-color-surface-slider-tick-mark: var(--primitive-color-sand-gray-55);
@@ -85,6 +82,10 @@ Semantic Color Tokens
 	--semantic-color-surface-tab-active: var(--primitive-color-active-red-55);
 	--semantic-color-surface-toast: var(--primitive-color-sand-gray-25);
 	--semantic-color-surface-tooltip: var(--primitive-color-sand-gray-25);
+	--semantic-color-surface-button-notification: var(--primitive-color-sand-gray-35);
+	--semantic-color-surface-access-bar: var(--primitive-color-sand-gray-50);
+	--semantic-color-surface-access-bar-app-gradient-start: var(--primitive-color-sand-gray-10);
+	--semantic-color-surface-access-bar-app-gradient-end: var(--primitive-color-sand-gray-25);
 
 	/* On Surface */
 	--semantic-color-on-surface-default-error: var(--primitive-color-deep-orange-60);
@@ -98,8 +99,6 @@ Semantic Color Tokens
 	--semantic-color-on-surface-accent-light: var(--primitive-color-cobalt-blue-65);
 	--semantic-color-on-surface-accent-light-disabled: var(--primitive-color-cobalt-blue-65);
 	--semantic-color-on-surface-black: var(--primitive-color-black);
-	--semantic-color-on-surface-navigation-bar-handle-dark: var(--primitive-color-black);
-	--semantic-color-on-surface-navigation-bar-handle-light: var(--primitive-color-white);
 	--semantic-color-on-surface-page-indicator-dark: var(--primitive-color-black);
 	--semantic-color-on-surface-page-indicator-light: var(--primitive-color-white);
 	--semantic-color-on-surface-picker-primary: var(--primitive-color-white);
@@ -107,6 +106,8 @@ Semantic Color Tokens
 	--semantic-color-on-surface-picker-tertiary: var(--primitive-color-white);
 	--semantic-color-on-surface-selection-checkmark-active-disabled: var(--primitive-color-sand-gray-55);
 	--semantic-color-on-surface-slider-handle: var(--primitive-color-cobalt-blue-50);
+	--semantic-color-on-surface-access-bar-handle-dark: var(--primitive-color-black);
+	--semantic-color-on-surface-access-bar-handle-light: var(--primitive-color-white);
 
 	/* Stroke */
 	--semantic-color-stroke-default-error: var(--primitive-color-deep-orange-60);
@@ -122,12 +123,12 @@ Semantic Color Tokens
 	--semantic-color-stroke-sub-supporting: var(--primitive-color-sand-gray-45);
 	--semantic-color-stroke-accent: var(--primitive-color-cobalt-blue-45);
 	--semantic-color-stroke-accent-disabled: var(--primitive-color-cobalt-blue-45);
-	--semantic-color-stroke-navigation-bar: var(--primitive-color-white);
-	--semantic-color-stroke-navigation-bar-app: var(--primitive-color-white);
 	--semantic-color-stroke-picker-color: var(--primitive-color-sand-gray-55);
 	--semantic-color-stroke-selection-inactive: var(--primitive-color-sand-gray-55);
 	--semantic-color-stroke-selection-inactive-disabled: var(--primitive-color-sand-gray-55);
 	--semantic-color-stroke-tab-active: var(--primitive-color-active-red-55);
+	--semantic-color-stroke-access-bar: var(--primitive-color-white);
+	--semantic-color-stroke-access-bar-app: var(--primitive-color-white);
 
 	/* Scrim */
 	--semantic-color-scrim-default: var(--primitive-color-black);

--- a/packages/webos-m-tokens/css/color-semantic-dark.css
+++ b/packages/webos-m-tokens/css/color-semantic-dark.css
@@ -67,6 +67,9 @@ Semantic Color Tokens
 	--semantic-color-surface-list-selected: var(--primitive-color-sand-gray-85);
 	--semantic-color-surface-menu: var(--primitive-color-sand-gray-25);
 	--semantic-color-surface-menu-selected: var(--primitive-color-sand-gray-85);
+	--semantic-color-surface-access-bar: var(--primitive-color-sand-gray-50);
+	--semantic-color-surface-access-bar-app-gradient-start: var(--primitive-color-sand-gray-10);
+	--semantic-color-surface-access-bar-app-gradient-end: var(--primitive-color-sand-gray-25);
 	--semantic-color-surface-picker-color: var(--primitive-color-white);
 	--semantic-color-surface-picker-date: var(--primitive-color-cobalt-blue-45);
 	--semantic-color-surface-slider-tick-mark: var(--primitive-color-sand-gray-55);
@@ -83,9 +86,6 @@ Semantic Color Tokens
 	--semantic-color-surface-toast: var(--primitive-color-sand-gray-25);
 	--semantic-color-surface-tooltip: var(--primitive-color-sand-gray-25);
 	--semantic-color-surface-button-notification: var(--primitive-color-sand-gray-35);
-	--semantic-color-surface-access-bar: var(--primitive-color-sand-gray-50);
-	--semantic-color-surface-access-bar-app-gradient-start: var(--primitive-color-sand-gray-10);
-	--semantic-color-surface-access-bar-app-gradient-end: var(--primitive-color-sand-gray-25);
 
 	/* On Surface */
 	--semantic-color-on-surface-default-error: var(--primitive-color-deep-orange-60);
@@ -99,6 +99,8 @@ Semantic Color Tokens
 	--semantic-color-on-surface-accent-light: var(--primitive-color-cobalt-blue-65);
 	--semantic-color-on-surface-accent-light-disabled: var(--primitive-color-cobalt-blue-65);
 	--semantic-color-on-surface-black: var(--primitive-color-black);
+	--semantic-color-on-surface-access-bar-handle-dark: var(--primitive-color-black);
+	--semantic-color-on-surface-access-bar-handle-light: var(--primitive-color-white);
 	--semantic-color-on-surface-page-indicator-dark: var(--primitive-color-black);
 	--semantic-color-on-surface-page-indicator-light: var(--primitive-color-white);
 	--semantic-color-on-surface-picker-primary: var(--primitive-color-white);
@@ -106,8 +108,6 @@ Semantic Color Tokens
 	--semantic-color-on-surface-picker-tertiary: var(--primitive-color-white);
 	--semantic-color-on-surface-selection-checkmark-active-disabled: var(--primitive-color-sand-gray-55);
 	--semantic-color-on-surface-slider-handle: var(--primitive-color-cobalt-blue-50);
-	--semantic-color-on-surface-access-bar-handle-dark: var(--primitive-color-black);
-	--semantic-color-on-surface-access-bar-handle-light: var(--primitive-color-white);
 
 	/* Stroke */
 	--semantic-color-stroke-default-error: var(--primitive-color-deep-orange-60);
@@ -123,12 +123,12 @@ Semantic Color Tokens
 	--semantic-color-stroke-sub-supporting: var(--primitive-color-sand-gray-45);
 	--semantic-color-stroke-accent: var(--primitive-color-cobalt-blue-45);
 	--semantic-color-stroke-accent-disabled: var(--primitive-color-cobalt-blue-45);
+	--semantic-color-stroke-access-bar: var(--primitive-color-white);
+	--semantic-color-stroke-access-bar-app: var(--primitive-color-white);
 	--semantic-color-stroke-picker-color: var(--primitive-color-sand-gray-55);
 	--semantic-color-stroke-selection-inactive: var(--primitive-color-sand-gray-55);
 	--semantic-color-stroke-selection-inactive-disabled: var(--primitive-color-sand-gray-55);
 	--semantic-color-stroke-tab-active: var(--primitive-color-active-red-55);
-	--semantic-color-stroke-access-bar: var(--primitive-color-white);
-	--semantic-color-stroke-access-bar-app: var(--primitive-color-white);
 
 	/* Scrim */
 	--semantic-color-scrim-default: var(--primitive-color-black);

--- a/packages/webos-m-tokens/css/radius-semantic.css
+++ b/packages/webos-m-tokens/css/radius-semantic.css
@@ -31,7 +31,6 @@ Semantic Radius Tokens
 	--semantic-radius-menu-m: var(--primitive-radius-24);
 	--semantic-radius-menu-s: var(--primitive-radius-18);
 	--semantic-radius-navigation-l: var(--primitive-radius-48);
-	--semantic-radius-navigation-m: var(--primitive-radius-40);
 	--semantic-radius-navigation-s: var(--primitive-radius-36);
 	--semantic-radius-notification-card: var(--primitive-radius-36);
 	--semantic-radius-ongoing-briefing: var(--primitive-radius-30);
@@ -59,4 +58,6 @@ Semantic Radius Tokens
 	--semantic-radius-toast: var(--primitive-radius-18);
 	--semantic-radius-tooltip: var(--primitive-radius-18);
 	--semantic-radius-home-grid-indicator: var(--primitive-radius-18);
+	--semantic-radius-access-bar-l: var(--primitive-radius-48);
+	--semantic-radius-access-bar-s: var(--primitive-radius-40);
 }

--- a/packages/webos-m-tokens/css/radius-semantic.css
+++ b/packages/webos-m-tokens/css/radius-semantic.css
@@ -12,6 +12,8 @@ Semantic Radius Tokens
 :root {
 
 	/* Radius */
+	--semantic-radius-access-bar-l: var(--primitive-radius-48);
+	--semantic-radius-access-bar-s: var(--primitive-radius-40);
 	--semantic-radius-app-icon-l: var(--primitive-radius-36);
 	--semantic-radius-app-icon-s: var(--primitive-radius-28);
 	--semantic-radius-badge: var(--primitive-radius-999);
@@ -58,6 +60,4 @@ Semantic Radius Tokens
 	--semantic-radius-toast: var(--primitive-radius-18);
 	--semantic-radius-tooltip: var(--primitive-radius-18);
 	--semantic-radius-home-grid-indicator: var(--primitive-radius-18);
-	--semantic-radius-access-bar-l: var(--primitive-radius-48);
-	--semantic-radius-access-bar-s: var(--primitive-radius-40);
 }

--- a/packages/webos-m-tokens/json/color-semantic-dark.json
+++ b/packages/webos-m-tokens/json/color-semantic-dark.json
@@ -32,15 +32,15 @@
                     "accent-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-65"},
                     "accent-light-disabled": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-65"},
                     "black": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
-                    "navigation-bar-handle-dark": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
-                    "navigation-bar-handle-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                     "page-indicator-dark": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
                     "page-indicator-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                     "picker-primary": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                     "picker-secondary": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                     "picker-tertiary": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                     "selection-checkmark-active-disabled": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-55"},
-                    "slider-handle": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-50"}
+                    "slider-handle": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-50"},
+                    "access-bar-handle-dark": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
+                    "access-bar-handle-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"}
                 }
             },
             "surface": {
@@ -81,9 +81,6 @@
                 "list-selected": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-85"},
                 "menu": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"},
                 "menu-selected": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-85"},
-                "navigation-bar": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-50"},
-                "navigation-bar-app-gradient-start": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-10"},
-                "navigation-bar-app-gradient-end": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"},
                 "picker-color": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                 "picker-date": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-45"},
                 "slider-tick-mark": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-55"},
@@ -98,7 +95,11 @@
                 "selection-checkbox-inactive-disabled": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-5"},
                 "tab-active": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/active-red-55"},
                 "toast": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"},
-                "tooltip": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"}
+                "tooltip": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"},
+                "button-notification": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-35"},
+                "access-bar": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-50"},
+                "access-bar-app-gradient-start": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-10"},
+                "access-bar-app-gradient-end": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"}
             },
             "stroke": {
                 "default-error": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/deep-orange-60"},
@@ -114,12 +115,12 @@
                 "sub-supporting": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-45"},
                 "accent": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-45"},
                 "accent-disabled": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-45"},
-                "navigation-bar": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
-                "navigation-bar-app": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                 "picker-color": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-55"},
                 "selection-inactive": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-55"},
                 "selection-inactive-disabled": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-55"},
-                "tab-active": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/active-red-55"}
+                "tab-active": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/active-red-55"},
+                "access-bar": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
+                "access-bar-app": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"}
             },
             "scrim": {
                 "default": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"}

--- a/packages/webos-m-tokens/json/color-semantic-dark.json
+++ b/packages/webos-m-tokens/json/color-semantic-dark.json
@@ -32,15 +32,15 @@
                     "accent-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-65"},
                     "accent-light-disabled": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-65"},
                     "black": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
+                    "access-bar-handle-dark": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
+                    "access-bar-handle-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                     "page-indicator-dark": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
                     "page-indicator-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                     "picker-primary": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                     "picker-secondary": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                     "picker-tertiary": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                     "selection-checkmark-active-disabled": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-55"},
-                    "slider-handle": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-50"},
-                    "access-bar-handle-dark": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
-                    "access-bar-handle-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"}
+                    "slider-handle": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-50"}
                 }
             },
             "surface": {
@@ -81,6 +81,9 @@
                 "list-selected": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-85"},
                 "menu": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"},
                 "menu-selected": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-85"},
+                "access-bar": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-50"},
+                "access-bar-app-gradient-start": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-10"},
+                "access-bar-app-gradient-end": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"},
                 "picker-color": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                 "picker-date": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-45"},
                 "slider-tick-mark": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-55"},
@@ -96,10 +99,7 @@
                 "tab-active": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/active-red-55"},
                 "toast": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"},
                 "tooltip": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"},
-                "button-notification": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-35"},
-                "access-bar": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-50"},
-                "access-bar-app-gradient-start": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-10"},
-                "access-bar-app-gradient-end": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"}
+                "button-notification": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-35"}
             },
             "stroke": {
                 "default-error": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/deep-orange-60"},
@@ -115,12 +115,12 @@
                 "sub-supporting": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-45"},
                 "accent": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-45"},
                 "accent-disabled": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-45"},
+                "access-bar": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
+                "access-bar-app": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                 "picker-color": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-55"},
                 "selection-inactive": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-55"},
                 "selection-inactive-disabled": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-55"},
-                "tab-active": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/active-red-55"},
-                "access-bar": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
-                "access-bar-app": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"}
+                "tab-active": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/active-red-55"}
             },
             "scrim": {
                 "default": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"}

--- a/packages/webos-m-tokens/json/radius-semantic.json
+++ b/packages/webos-m-tokens/json/radius-semantic.json
@@ -20,7 +20,6 @@
             "menu-m": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-24"},
             "menu-s": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
             "navigation-l": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-48"},
-            "navigation-m": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-40"},
             "navigation-s": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"},
             "notification-card": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"},
             "ongoing-briefing": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-30"},
@@ -47,7 +46,9 @@
             "thumbnail-xs": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
             "toast": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
             "tooltip": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
-            "home-grid-indicator": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"}
+            "home-grid-indicator": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
+            "access-bar-l": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-48"},
+            "access-bar-s": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-40"}
         }
     }
 }

--- a/packages/webos-m-tokens/json/radius-semantic.json
+++ b/packages/webos-m-tokens/json/radius-semantic.json
@@ -1,6 +1,8 @@
 {
     "semantic": {
         "radius": {
+            "access-bar-l": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-48"},
+            "access-bar-s": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-40"},
             "app-icon-l": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"},
             "app-icon-s": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-28"},
             "badge": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
@@ -46,9 +48,7 @@
             "thumbnail-xs": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
             "toast": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
             "tooltip": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
-            "home-grid-indicator": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
-            "access-bar-l": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-48"},
-            "access-bar-s": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-40"}
+            "home-grid-indicator": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"}
         }
     }
 }

--- a/scripts/figma-sync.js
+++ b/scripts/figma-sync.js
@@ -653,13 +653,9 @@ function analyzeChanges(figmaTokens, localTokens) {
 						localTokens = localTokens.semantic.color;
 					}
 					
-					// For radius semantic collections, navigate to the radius structure
-					if (collectionName.includes('radius.semantic') && localTokens.semantic && localTokens.semantic.radius) {
-						localTokens = localTokens.semantic.radius;
-						// Also navigate Figma tokens to radius structure
-						if (figmaTokensForCollection.radius) {
-							figmaTokensForCollection = figmaTokensForCollection.radius;
-						}
+					// For radius semantic collections, skip here - compareSemanticRadiusTokens handles removed check
+					if (collectionName.includes('radius.semantic')) {
+						return;
 					}
 
 					// For effect semantic collections, skip here - compareSemanticEffectTokens handles removed check
@@ -1248,7 +1244,7 @@ function compareSemanticRadiusTokens(figmaCollection, localSemanticRadiusTokens,
 						// Values are different
 						const mappedChange = mapToLocalStructure(collectionName, packageName, ['radius', tokenName], localValue, figmaValue);
 						if (mappedChange) {
-							changes.modified[`${packageName}/radius-semantic/radius-${tokenName}`] = mappedChange;
+							changes.modified[pathString] = mappedChange;
 							console.log(`Found modified semantic radius token: ${pathString}`);
 							console.log(`  Local $ref resolved: ${resolvedValue} → Figma: ${figmaValue}`);
 						}
@@ -1277,7 +1273,7 @@ function compareSemanticRadiusTokens(figmaCollection, localSemanticRadiusTokens,
 				// Direct value comparison
 				const mappedChange = mapToLocalStructure(collectionName, packageName, ['radius', tokenName], localValue, figmaValue);
 				if (mappedChange) {
-					changes.modified[`${packageName}/radius-semantic/radius-${tokenName}`] = mappedChange;
+					changes.modified[pathString] = mappedChange;
 					console.log(`Found modified semantic radius token: ${pathString}`);
 					console.log(`  Local: ${localValue} → Figma: ${figmaValue}`);
 				}
@@ -1597,10 +1593,14 @@ function mapToLocalStructure(collectionName, packageName, figmaPath, beforeValue
 	}
 
 	// Handle webOS semantic radius tokens
-	if (collectionName === 'lg.webOS.radius.semantic' && figmaPath.length >= 1) {
+	if ((collectionName === 'lg.webOS.radius.semantic' || 
+		 collectionName === 'lg.webOSmicro.radius.semantic') && figmaPath.length >= 1) {
 		// Create nested structure for semantic radius tokens
-		// figmaPath example: ['radius', 'full']
-		// Maps to: semantic.radius.full
+		// figmaPath example: ['radius', 'full'] or ['radius', 'picker-xs']
+		// Maps to: semantic.radius.full or semantic.radius.picker-xs
+		
+		// Skip the first 'radius' element if present, as we already have semantic.radius structure
+		const actualPath = figmaPath[0] === 'radius' ? figmaPath.slice(1) : figmaPath;
 
 		let beforeStructure = { semantic: { radius: {} } };
 		let afterStructure = { semantic: { radius: {} } };
@@ -1609,15 +1609,15 @@ function mapToLocalStructure(collectionName, packageName, figmaPath, beforeValue
 		let beforeCurrent = beforeStructure.semantic.radius;
 		let afterCurrent = afterStructure.semantic.radius;
 
-		for (let i = 0; i < figmaPath.length - 1; i++) {
-			beforeCurrent[figmaPath[i]] = {};
-			afterCurrent[figmaPath[i]] = {};
-			beforeCurrent = beforeCurrent[figmaPath[i]];
-			afterCurrent = afterCurrent[figmaPath[i]];
+		for (let i = 0; i < actualPath.length - 1; i++) {
+			beforeCurrent[actualPath[i]] = {};
+			afterCurrent[actualPath[i]] = {};
+			beforeCurrent = beforeCurrent[actualPath[i]];
+			afterCurrent = afterCurrent[actualPath[i]];
 		}
 
 		// Set the final value
-		const finalKey = figmaPath[figmaPath.length - 1];
+		const finalKey = actualPath[actualPath.length - 1];
 		beforeCurrent[finalKey] = beforeValue;
 		afterCurrent[finalKey] = afterValue;
 


### PR DESCRIPTION
### Checklist

[//]: # (Contribution guide should be added)
* [X] A CHANGELOG entry is included  
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
This pull request introduces several updates to the webOS M tokens, focusing on semantic token renaming for consistency, removal of deprecated tokens, and the addition of new tokens for enhanced UI flexibility. The most significant changes are grouped below.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
**Token Renaming and Removal:**

- Renamed all `navigation-bar` related semantic color and radius tokens to `access-bar` across code, CSS, and JSON files for consistency. This affects properties such as `surface`, `stroke`, and `on-surface` [[1]](diffhunk://#diff-a9709b47db691266ff4ceab50a8cf974f568982ae664f082b8a7e55ce60f1efcL89-R95) [[2]](diffhunk://#diff-e0efe55eba55bbfe65098b4a1d6daa2229116121f6a6174edcf187dc6fabe095L41-R43) [[3]](diffhunk://#diff-8082ff13112fd42d3957eab568b810aca8c797fd07e54b34242228642a23c589L37-R39) [[4]](diffhunk://#diff-1f3861f37fcebd239f635468731e599b81f81b78265e76246a31426ddf19b6a7L70-R72) [[5]](diffhunk://#diff-1f3861f37fcebd239f635468731e599b81f81b78265e76246a31426ddf19b6a7L101-R103) [[6]](diffhunk://#diff-1f3861f37fcebd239f635468731e599b81f81b78265e76246a31426ddf19b6a7L125-R127) [[7]](diffhunk://#diff-2587950dd06cd710cdf03afa31444f62479f396b701a56dd86f08778144a9b84L35-R36) [[8]](diffhunk://#diff-2587950dd06cd710cdf03afa31444f62479f396b701a56dd86f08778144a9b84L84-R86) [[9]](diffhunk://#diff-2587950dd06cd710cdf03afa31444f62479f396b701a56dd86f08778144a9b84L117-R119).
- Removed the deprecated `semantic-radius-navigation-m` token from all relevant files [[1]](diffhunk://#diff-b2186646c750bf1767b6deaf7f6f5f8b4850a71955b263704d9cbe70953174efL32) [[2]](diffhunk://#diff-501c3d63e2ceaec096463414aa0c97bff3d65c1916f93079d946fe876c06cc2dL34) [[3]](diffhunk://#diff-0e2f162fef7a425a364f631b51d77574a6e89975ed5ae8469e95767199f76c52L23) [[4]](diffhunk://#diff-651bb9fbf832d38113915eaf1ae8e7489541f9d17c118ba900c8525b29760431R5-R25) [[5]](diffhunk://#diff-01e535ee935550e0427c8a83ff4103767d9a404a9915729ee0e044f4b05fe410R5-R25).

**New Token Additions:**

- Added new semantic color token: `semantic_color_surface_button_notification`, and its corresponding CSS and JSON definitions [[1]](diffhunk://#diff-a9709b47db691266ff4ceab50a8cf974f568982ae664f082b8a7e55ce60f1efcR61-R62) [[2]](diffhunk://#diff-1f3861f37fcebd239f635468731e599b81f81b78265e76246a31426ddf19b6a7R88) [[3]](diffhunk://#diff-2587950dd06cd710cdf03afa31444f62479f396b701a56dd86f08778144a9b84L101-R102) [[4]](diffhunk://#diff-651bb9fbf832d38113915eaf1ae8e7489541f9d17c118ba900c8525b29760431R5-R25) [[5]](diffhunk://#diff-01e535ee935550e0427c8a83ff4103767d9a404a9915729ee0e044f4b05fe410R5-R25).
- Introduced new radius tokens: `semantic_radius_access_bar_l` and `semantic_radius_access_bar_s` to support additional UI shapes [[1]](diffhunk://#diff-b2186646c750bf1767b6deaf7f6f5f8b4850a71955b263704d9cbe70953174efR13-R14) [[2]](diffhunk://#diff-501c3d63e2ceaec096463414aa0c97bff3d65c1916f93079d946fe876c06cc2dR15-R16) [[3]](diffhunk://#diff-0e2f162fef7a425a364f631b51d77574a6e89975ed5ae8469e95767199f76c52R4-R5) [[4]](diffhunk://#diff-651bb9fbf832d38113915eaf1ae8e7489541f9d17c118ba900c8525b29760431R5-R25) [[5]](diffhunk://#diff-01e535ee935550e0427c8a83ff4103767d9a404a9915729ee0e044f4b05fe410R5-R25).

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

**Tooling and Script Updates:**

- Updated the Figma sync script to improve handling of semantic radius tokens, ensuring removed checks are handled in the correct function and fixing the way modified tokens are tracked [[1]](diffhunk://#diff-c8649c36bcf54c926c4502a02acbc850848826b8a353e84e6d94f9e2fd76dc15L656-R658) [[2]](diffhunk://#diff-c8649c36bcf54c926c4502a02acbc850848826b8a353e84e6d94f9e2fd76dc15L1251-R1247) [[3]](diffhunk://#diff-c8649c36bcf54c926c4502a02acbc850848826b8a353e84e6d94f9e2fd76dc15L1280-R1276).


### Links
[//]: # (Related issues, references)
ATL-22376

### Comments
[//]: # (DCO should be here)
Enovaui-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)
