### PR TITLE
ATL-23339: [webos-m] Updated color, radius semantic tokens

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 The following is a curated list of changes in the flutter tokens module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `semantic_radius_selection_control` to `semantic_radius_selection_control_full`
+
+### Added
+
+- `semantic_color_on_surface_status_bar_floating_orange`
+- `semantic_color_on_surface_status_bar_floating_red`
+- `semantic_radius_floating_window`
+- `semantic_radius_selection_control_s`
+
 ## [3.3.0] - 2026-06-18
 
 ### Removed

--- a/lib/src/webos_m_tokens/base/color/on_surface/on_surface_base.dart
+++ b/lib/src/webos_m_tokens/base/color/on_surface/on_surface_base.dart
@@ -28,4 +28,6 @@ abstract class OnSurfaceBase {
   Color get pickerTertiary;
   Color get selectionCheckmarkActiveDisabled;
   Color get sliderHandle;
+  Color get statusBarFloatingOrange;
+  Color get statusBarFloatingRed;
 }

--- a/lib/src/webos_m_tokens/dark/color/on_surface/on_surface.dart
+++ b/lib/src/webos_m_tokens/dark/color/on_surface/on_surface.dart
@@ -51,4 +51,8 @@ class OnSurface extends OnSurfaceBase {
   Color get selectionCheckmarkActiveDisabled => ColorPrimitive.instance.sandGray55;
   @override
   Color get sliderHandle => ColorPrimitive.instance.cobaltBlue50;
+  @override
+  Color get statusBarFloatingOrange => ColorPrimitive.instance.deepOrange40;
+  @override
+  Color get statusBarFloatingRed => ColorPrimitive.instance.activeRed55;
 }

--- a/lib/src/webos_m_tokens/radius_semantic.dart
+++ b/lib/src/webos_m_tokens/radius_semantic.dart
@@ -44,7 +44,6 @@ class RadiusSemantic {
   Radius get quickSettingsS => RadiusPrimitive.instance.radius36;
   Radius get scrollBar => RadiusPrimitive.instance.radius999;
   Radius get search => RadiusPrimitive.instance.radius18;
-  Radius get selectionControl => RadiusPrimitive.instance.radius999;
   Radius get sideSheet => RadiusPrimitive.instance.radius48;
   Radius get slider => RadiusPrimitive.instance.radius999;
   Radius get statusBar => RadiusPrimitive.instance.radius999;
@@ -57,4 +56,7 @@ class RadiusSemantic {
   Radius get toast => RadiusPrimitive.instance.radius18;
   Radius get tooltip => RadiusPrimitive.instance.radius18;
   Radius get homeGridIndicator => RadiusPrimitive.instance.radius18;
+  Radius get floatingWindow => RadiusPrimitive.instance.radius12;
+  Radius get selectionControlFull => RadiusPrimitive.instance.radius999;
+  Radius get selectionControlS => RadiusPrimitive.instance.radius36;
 }

--- a/lib/src/webos_m_tokens/radius_semantic.dart
+++ b/lib/src/webos_m_tokens/radius_semantic.dart
@@ -22,6 +22,7 @@ class RadiusSemantic {
   Radius get card => RadiusPrimitive.instance.radius36;
   Radius get chip => RadiusPrimitive.instance.radius999;
   Radius get dialogPopup => RadiusPrimitive.instance.radius36;
+  Radius get floatingWindow => RadiusPrimitive.instance.radius12;
   Radius get handle => RadiusPrimitive.instance.radius999;
   Radius get iconGrid => RadiusPrimitive.instance.radius999;
   Radius get listL => RadiusPrimitive.instance.radius36;
@@ -44,6 +45,8 @@ class RadiusSemantic {
   Radius get quickSettingsS => RadiusPrimitive.instance.radius36;
   Radius get scrollBar => RadiusPrimitive.instance.radius999;
   Radius get search => RadiusPrimitive.instance.radius18;
+  Radius get selectionControlFull => RadiusPrimitive.instance.radius999;
+  Radius get selectionControlS => RadiusPrimitive.instance.radius36;
   Radius get sideSheet => RadiusPrimitive.instance.radius48;
   Radius get slider => RadiusPrimitive.instance.radius999;
   Radius get statusBar => RadiusPrimitive.instance.radius999;
@@ -56,7 +59,4 @@ class RadiusSemantic {
   Radius get toast => RadiusPrimitive.instance.radius18;
   Radius get tooltip => RadiusPrimitive.instance.radius18;
   Radius get homeGridIndicator => RadiusPrimitive.instance.radius18;
-  Radius get floatingWindow => RadiusPrimitive.instance.radius12;
-  Radius get selectionControlFull => RadiusPrimitive.instance.radius999;
-  Radius get selectionControlS => RadiusPrimitive.instance.radius36;
 }

--- a/packages/webos-m-tokens/CHANGELOG.md
+++ b/packages/webos-m-tokens/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 The following is a curated list of changes in the webos tokens module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `semantic-radius-selection-control` to `semantic-radius-selection-control-full`
+
+### Added
+
+- `semantic-color-on-surface-status-bar-floating-orange`
+- `semantic-color-on-surface-status-bar-floating-red`
+- `semantic-radius-floating-window`
+- `semantic-radius-selection-control-s`
+
 ## [3.3.0] - 2026-06-18
 
 ### Removed

--- a/packages/webos-m-tokens/css/color-semantic-dark.css
+++ b/packages/webos-m-tokens/css/color-semantic-dark.css
@@ -108,6 +108,8 @@ Semantic Color Tokens
 	--semantic-color-on-surface-picker-tertiary: var(--primitive-color-white);
 	--semantic-color-on-surface-selection-checkmark-active-disabled: var(--primitive-color-sand-gray-55);
 	--semantic-color-on-surface-slider-handle: var(--primitive-color-cobalt-blue-50);
+	--semantic-color-on-surface-status-bar-floating-orange: var(--primitive-color-deep-orange-40);
+	--semantic-color-on-surface-status-bar-floating-red: var(--primitive-color-active-red-55);
 
 	/* Stroke */
 	--semantic-color-stroke-default-error: var(--primitive-color-deep-orange-60);

--- a/packages/webos-m-tokens/css/radius-semantic.css
+++ b/packages/webos-m-tokens/css/radius-semantic.css
@@ -24,6 +24,7 @@ Semantic Radius Tokens
 	--semantic-radius-card: var(--primitive-radius-36);
 	--semantic-radius-chip: var(--primitive-radius-999);
 	--semantic-radius-dialog-popup: var(--primitive-radius-36);
+	--semantic-radius-floating-window: var(--primitive-radius-12);
 	--semantic-radius-handle: var(--primitive-radius-999);
 	--semantic-radius-icon-grid: var(--primitive-radius-999);
 	--semantic-radius-list-l: var(--primitive-radius-36);
@@ -46,6 +47,8 @@ Semantic Radius Tokens
 	--semantic-radius-quick-settings-s: var(--primitive-radius-36);
 	--semantic-radius-scroll-bar: var(--primitive-radius-999);
 	--semantic-radius-search: var(--primitive-radius-18);
+	--semantic-radius-selection-control-full: var(--primitive-radius-999);
+	--semantic-radius-selection-control-s: var(--primitive-radius-36);
 	--semantic-radius-side-sheet: var(--primitive-radius-48);
 	--semantic-radius-slider: var(--primitive-radius-999);
 	--semantic-radius-status-bar: var(--primitive-radius-999);
@@ -58,7 +61,4 @@ Semantic Radius Tokens
 	--semantic-radius-toast: var(--primitive-radius-18);
 	--semantic-radius-tooltip: var(--primitive-radius-18);
 	--semantic-radius-home-grid-indicator: var(--primitive-radius-18);
-	--semantic-radius-floating-window: var(--primitive-radius-12);
-	--semantic-radius-selection-control-full: var(--primitive-radius-999);
-	--semantic-radius-selection-control-s: var(--primitive-radius-36);
 }

--- a/packages/webos-m-tokens/css/radius-semantic.css
+++ b/packages/webos-m-tokens/css/radius-semantic.css
@@ -46,7 +46,6 @@ Semantic Radius Tokens
 	--semantic-radius-quick-settings-s: var(--primitive-radius-36);
 	--semantic-radius-scroll-bar: var(--primitive-radius-999);
 	--semantic-radius-search: var(--primitive-radius-18);
-	--semantic-radius-selection-control: var(--primitive-radius-999);
 	--semantic-radius-side-sheet: var(--primitive-radius-48);
 	--semantic-radius-slider: var(--primitive-radius-999);
 	--semantic-radius-status-bar: var(--primitive-radius-999);
@@ -59,4 +58,7 @@ Semantic Radius Tokens
 	--semantic-radius-toast: var(--primitive-radius-18);
 	--semantic-radius-tooltip: var(--primitive-radius-18);
 	--semantic-radius-home-grid-indicator: var(--primitive-radius-18);
+	--semantic-radius-floating-window: var(--primitive-radius-12);
+	--semantic-radius-selection-control-full: var(--primitive-radius-999);
+	--semantic-radius-selection-control-s: var(--primitive-radius-36);
 }

--- a/packages/webos-m-tokens/json/color-semantic-dark.json
+++ b/packages/webos-m-tokens/json/color-semantic-dark.json
@@ -40,7 +40,9 @@
                     "picker-secondary": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                     "picker-tertiary": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                     "selection-checkmark-active-disabled": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-55"},
-                    "slider-handle": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-50"}
+                    "slider-handle": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-50"},
+                    "status-bar-floating-orange": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/deep-orange-40"},
+                    "status-bar-floating-red": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/active-red-55"}
                 }
             },
             "surface": {

--- a/packages/webos-m-tokens/json/radius-semantic.json
+++ b/packages/webos-m-tokens/json/radius-semantic.json
@@ -13,6 +13,7 @@
             "card": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"},
             "chip": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
             "dialog-popup": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"},
+            "floating-window": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-12"},
             "handle": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
             "icon-grid": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
             "list-l": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"},
@@ -35,6 +36,8 @@
             "quick-settings-s": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"},
             "scroll-bar": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
             "search": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
+            "selection-control-full": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
+            "selection-control-s": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"},
             "side-sheet": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-48"},
             "slider": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
             "status-bar": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
@@ -46,10 +49,7 @@
             "thumbnail-xs": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
             "toast": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
             "tooltip": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
-            "home-grid-indicator": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
-            "floating-window": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-12"},
-            "selection-control-full": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
-            "selection-control-s": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"}
+            "home-grid-indicator": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"}
         }
     }
 }

--- a/packages/webos-m-tokens/json/radius-semantic.json
+++ b/packages/webos-m-tokens/json/radius-semantic.json
@@ -35,7 +35,6 @@
             "quick-settings-s": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"},
             "scroll-bar": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
             "search": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
-            "selection-control": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
             "side-sheet": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-48"},
             "slider": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
             "status-bar": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
@@ -47,7 +46,10 @@
             "thumbnail-xs": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
             "toast": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
             "tooltip": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
-            "home-grid-indicator": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"}
+            "home-grid-indicator": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
+            "floating-window": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-12"},
+            "selection-control-full": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
+            "selection-control-s": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"}
         }
     }
 }


### PR DESCRIPTION
### Checklist

[//]: # (Contribution guide should be added)
* [x] A CHANGELOG entry is included  
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Updated color, radius semantic tokens
This pull request updates the semantic color and radius tokens for the webOS M design system. It introduces new tokens for status bar colors and floating window radius, and refines the naming and granularity of selection control radius tokens to support more specific use cases. The changes are reflected across Dart source files, CSS, and JSON token definitions, as well as in the corresponding changelogs.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
**Semantic Color Token Updates:**

* Added new semantic color tokens for status bar floating states: `on-surface-status-bar-floating-orange` and `on-surface-status-bar-floating-red` in Dart (`OnSurfaceBase`, `OnSurface`), CSS, and JSON files.

**Semantic Radius Token Updates:**

* Added a new semantic radius token for `floating-window` in Dart, CSS, and JSON files. 
* Refined selection control radius tokens:
  - Renamed `selection-control` to `selection-control-full`
  - Added `selection-control-s` for a smaller variant
  - Updated in Dart, CSS, and JSON files

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ATL-23339

### Comments
[//]: # (DCO should be here)
Enovaui-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)
