### PR TITLE
ATL-23995: Update webos_m_tokens color and radius semantic tokens 

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 The following is a curated list of changes in the flutter tokens module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `semantic_color_effect_drop_shadow` to `semantic_color_effect_default_drop_shadow`
+- `semantic_color_effect_inner_shadow` to `semantic_color_effect_default_inner_shadow`
+
+### Added
+
+- `semantic_color_surface_button_icon_focused`
+- `semantic_color_surface_snackbar`
+- `semantic_radius_snackbar`
+
 ## [3.4.0] - 2026-06-26
 
 ### Changed

--- a/lib/src/webos_m_tokens/base/color/effect/effect_base.dart
+++ b/lib/src/webos_m_tokens/base/color/effect/effect_base.dart
@@ -8,8 +8,8 @@ import 'package:flutter/material.dart';
 abstract class EffectBase {
   const EffectBase();
 
-  Color get innerShadow;
-  Color get dropShadow;
+  Color get defaultDropShadow;
+  Color get defaultInnerShadow;
   Color get homeGridDropShadowDark;
   Color get homeGridDropShadowLight;
   Color get pageIndicatorDropShadowDark;

--- a/lib/src/webos_m_tokens/base/color/surface/surface_base.dart
+++ b/lib/src/webos_m_tokens/base/color/surface/surface_base.dart
@@ -29,6 +29,7 @@ abstract class SurfaceBase {
   Color get buttonTertiaryDisabled;
   Color get buttonTintPressed;
   Color get buttonIcon;
+  Color get buttonIconFocused;
   Color get buttonIconSelected;
   Color get buttonIconDisabled;
   Color get buttonNotification;
@@ -53,6 +54,7 @@ abstract class SurfaceBase {
   Color get pickerDate;
   Color get sliderTickMark;
   Color get scrollBarHandle;
+  Color get snackbar;
   Color get statusBar;
   Color get selectionActive;
   Color get selectionActiveDisabled;

--- a/lib/src/webos_m_tokens/dark/color/effect/effect.dart
+++ b/lib/src/webos_m_tokens/dark/color/effect/effect.dart
@@ -12,10 +12,6 @@ class Effect extends EffectBase {
   const Effect();
 
   @override
-  Color get innerShadow => ColorPrimitive.instance.white;
-  @override
-  Color get dropShadow => ColorPrimitive.instance.black;
-  @override
   Color get homeGridDropShadowDark => ColorPrimitive.instance.black;
   @override
   Color get homeGridDropShadowLight => ColorPrimitive.instance.white;
@@ -27,4 +23,8 @@ class Effect extends EffectBase {
   Color get statusBarDropShadowDark => ColorPrimitive.instance.black;
   @override
   Color get statusBarDropShadowLight => ColorPrimitive.instance.white;
+  @override
+  Color get defaultDropShadow => ColorPrimitive.instance.black;
+  @override
+  Color get defaultInnerShadow => ColorPrimitive.instance.white;
 }

--- a/lib/src/webos_m_tokens/dark/color/effect/effect.dart
+++ b/lib/src/webos_m_tokens/dark/color/effect/effect.dart
@@ -12,6 +12,10 @@ class Effect extends EffectBase {
   const Effect();
 
   @override
+  Color get defaultDropShadow => ColorPrimitive.instance.black;
+  @override
+  Color get defaultInnerShadow => ColorPrimitive.instance.white;
+  @override
   Color get homeGridDropShadowDark => ColorPrimitive.instance.black;
   @override
   Color get homeGridDropShadowLight => ColorPrimitive.instance.white;
@@ -23,8 +27,4 @@ class Effect extends EffectBase {
   Color get statusBarDropShadowDark => ColorPrimitive.instance.black;
   @override
   Color get statusBarDropShadowLight => ColorPrimitive.instance.white;
-  @override
-  Color get defaultDropShadow => ColorPrimitive.instance.black;
-  @override
-  Color get defaultInnerShadow => ColorPrimitive.instance.white;
 }

--- a/lib/src/webos_m_tokens/dark/color/surface/surface.dart
+++ b/lib/src/webos_m_tokens/dark/color/surface/surface.dart
@@ -58,8 +58,6 @@ class Surface extends SurfaceBase {
   @override
   Color get buttonIconDisabled => ColorPrimitive.instance.sandGray30;
   @override
-  Color get buttonNotification => ColorPrimitive.instance.sandGray35;
-  @override
   Color get chip => ColorPrimitive.instance.sandGray30;
   @override
   Color get chipSelected => ColorPrimitive.instance.cobaltBlue40;
@@ -123,4 +121,10 @@ class Surface extends SurfaceBase {
   Color get toast => ColorPrimitive.instance.sandGray25;
   @override
   Color get tooltip => ColorPrimitive.instance.sandGray25;
+  @override
+  Color get buttonNotification => ColorPrimitive.instance.sandGray35;
+  @override
+  Color get buttonIconFocused => ColorPrimitive.instance.white;
+  @override
+  Color get snackbar => ColorPrimitive.instance.sandGray25;
 }

--- a/lib/src/webos_m_tokens/dark/color/surface/surface.dart
+++ b/lib/src/webos_m_tokens/dark/color/surface/surface.dart
@@ -54,9 +54,13 @@ class Surface extends SurfaceBase {
   @override
   Color get buttonIcon => ColorPrimitive.instance.sandGray30;
   @override
+  Color get buttonIconFocused => ColorPrimitive.instance.white;
+  @override
   Color get buttonIconSelected => ColorPrimitive.instance.cobaltBlue45;
   @override
   Color get buttonIconDisabled => ColorPrimitive.instance.sandGray30;
+  @override
+  Color get buttonNotification => ColorPrimitive.instance.sandGray35;
   @override
   Color get chip => ColorPrimitive.instance.sandGray30;
   @override
@@ -100,6 +104,8 @@ class Surface extends SurfaceBase {
   @override
   Color get scrollBarHandle => ColorPrimitive.instance.sandGray55;
   @override
+  Color get snackbar => ColorPrimitive.instance.sandGray25;
+  @override
   Color get statusBar => ColorPrimitive.instance.sandGray25;
   @override
   Color get selectionActive => ColorPrimitive.instance.cobaltBlue45;
@@ -121,10 +127,4 @@ class Surface extends SurfaceBase {
   Color get toast => ColorPrimitive.instance.sandGray25;
   @override
   Color get tooltip => ColorPrimitive.instance.sandGray25;
-  @override
-  Color get buttonNotification => ColorPrimitive.instance.sandGray35;
-  @override
-  Color get buttonIconFocused => ColorPrimitive.instance.white;
-  @override
-  Color get snackbar => ColorPrimitive.instance.sandGray25;
 }

--- a/lib/src/webos_m_tokens/radius_semantic.dart
+++ b/lib/src/webos_m_tokens/radius_semantic.dart
@@ -59,4 +59,5 @@ class RadiusSemantic {
   Radius get toast => RadiusPrimitive.instance.radius18;
   Radius get tooltip => RadiusPrimitive.instance.radius18;
   Radius get homeGridIndicator => RadiusPrimitive.instance.radius18;
+  Radius get snackbar => RadiusPrimitive.instance.radius18;
 }

--- a/lib/src/webos_m_tokens/radius_semantic.dart
+++ b/lib/src/webos_m_tokens/radius_semantic.dart
@@ -24,6 +24,7 @@ class RadiusSemantic {
   Radius get dialogPopup => RadiusPrimitive.instance.radius36;
   Radius get floatingWindow => RadiusPrimitive.instance.radius12;
   Radius get handle => RadiusPrimitive.instance.radius999;
+  Radius get homeGridIndicator => RadiusPrimitive.instance.radius18;
   Radius get iconGrid => RadiusPrimitive.instance.radius999;
   Radius get listL => RadiusPrimitive.instance.radius36;
   Radius get listS => RadiusPrimitive.instance.radius24;
@@ -49,6 +50,7 @@ class RadiusSemantic {
   Radius get selectionControlS => RadiusPrimitive.instance.radius36;
   Radius get sideSheet => RadiusPrimitive.instance.radius48;
   Radius get slider => RadiusPrimitive.instance.radius999;
+  Radius get snackbar => RadiusPrimitive.instance.radius18;
   Radius get statusBar => RadiusPrimitive.instance.radius999;
   Radius get textField => RadiusPrimitive.instance.radius18;
   Radius get thumbnailXl => RadiusPrimitive.instance.radius42;
@@ -58,6 +60,4 @@ class RadiusSemantic {
   Radius get thumbnailXs => RadiusPrimitive.instance.radius18;
   Radius get toast => RadiusPrimitive.instance.radius18;
   Radius get tooltip => RadiusPrimitive.instance.radius18;
-  Radius get homeGridIndicator => RadiusPrimitive.instance.radius18;
-  Radius get snackbar => RadiusPrimitive.instance.radius18;
 }

--- a/packages/webos-m-tokens/CHANGELOG.md
+++ b/packages/webos-m-tokens/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 The following is a curated list of changes in the webos tokens module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `semantic-color-effect-drop-shadow` to `semantic-color-effect-default-drop-shadow`
+- `semantic-color-effect-inner-shadow` to `semantic-color-effect-default-inner-shadow`
+
+### Added
+
+- `semantic-color-surface-button-icon-focused`
+- `semantic-color-surface-snackbar`
+- `semantic-radius-snackbar`
+
 ## [3.4.0] - 2026-06-26
 
 ### Changed

--- a/packages/webos-m-tokens/css/color-semantic-dark.css
+++ b/packages/webos-m-tokens/css/color-semantic-dark.css
@@ -86,6 +86,8 @@ Semantic Color Tokens
 	--semantic-color-surface-toast: var(--primitive-color-sand-gray-25);
 	--semantic-color-surface-tooltip: var(--primitive-color-sand-gray-25);
 	--semantic-color-surface-button-notification: var(--primitive-color-sand-gray-35);
+	--semantic-color-surface-button-icon-focused: var(--primitive-color-white);
+	--semantic-color-surface-snackbar: var(--primitive-color-sand-gray-25);
 
 	/* On Surface */
 	--semantic-color-on-surface-default-error: var(--primitive-color-deep-orange-60);
@@ -136,12 +138,12 @@ Semantic Color Tokens
 	--semantic-color-scrim-default: var(--primitive-color-black);
 
 	/* Effect */
-	--semantic-color-effect-inner-shadow: var(--primitive-color-white);
-	--semantic-color-effect-drop-shadow: var(--primitive-color-black);
 	--semantic-color-effect-home-grid-drop-shadow-dark: var(--primitive-color-black);
 	--semantic-color-effect-home-grid-drop-shadow-light: var(--primitive-color-white);
 	--semantic-color-effect-page-indicator-drop-shadow-dark: var(--primitive-color-black);
 	--semantic-color-effect-page-indicator-drop-shadow-light: var(--primitive-color-white);
 	--semantic-color-effect-status-bar-drop-shadow-dark: var(--primitive-color-black);
 	--semantic-color-effect-status-bar-drop-shadow-light: var(--primitive-color-white);
+	--semantic-color-effect-default-drop-shadow: var(--primitive-color-black);
+	--semantic-color-effect-default-inner-shadow: var(--primitive-color-white);
 }

--- a/packages/webos-m-tokens/css/color-semantic-dark.css
+++ b/packages/webos-m-tokens/css/color-semantic-dark.css
@@ -51,8 +51,10 @@ Semantic Color Tokens
 	--semantic-color-surface-button-tertiary-disabled: var(--primitive-color-sand-gray-30);
 	--semantic-color-surface-button-tint-pressed: var(--primitive-color-black);
 	--semantic-color-surface-button-icon: var(--primitive-color-sand-gray-30);
+	--semantic-color-surface-button-icon-focused: var(--primitive-color-white);
 	--semantic-color-surface-button-icon-selected: var(--primitive-color-cobalt-blue-45);
 	--semantic-color-surface-button-icon-disabled: var(--primitive-color-sand-gray-30);
+	--semantic-color-surface-button-notification: var(--primitive-color-sand-gray-35);
 	--semantic-color-surface-chip: var(--primitive-color-sand-gray-30);
 	--semantic-color-surface-chip-selected: var(--primitive-color-cobalt-blue-40);
 	--semantic-color-surface-chip-disabled: var(--primitive-color-sand-gray-30);
@@ -74,6 +76,7 @@ Semantic Color Tokens
 	--semantic-color-surface-picker-date: var(--primitive-color-cobalt-blue-45);
 	--semantic-color-surface-slider-tick-mark: var(--primitive-color-sand-gray-55);
 	--semantic-color-surface-scroll-bar-handle: var(--primitive-color-sand-gray-55);
+	--semantic-color-surface-snackbar: var(--primitive-color-sand-gray-25);
 	--semantic-color-surface-status-bar: var(--primitive-color-sand-gray-25);
 	--semantic-color-surface-selection-active: var(--primitive-color-cobalt-blue-45);
 	--semantic-color-surface-selection-active-disabled: var(--primitive-color-cobalt-blue-45);
@@ -85,9 +88,6 @@ Semantic Color Tokens
 	--semantic-color-surface-tab-active: var(--primitive-color-active-red-55);
 	--semantic-color-surface-toast: var(--primitive-color-sand-gray-25);
 	--semantic-color-surface-tooltip: var(--primitive-color-sand-gray-25);
-	--semantic-color-surface-button-notification: var(--primitive-color-sand-gray-35);
-	--semantic-color-surface-button-icon-focused: var(--primitive-color-white);
-	--semantic-color-surface-snackbar: var(--primitive-color-sand-gray-25);
 
 	/* On Surface */
 	--semantic-color-on-surface-default-error: var(--primitive-color-deep-orange-60);
@@ -138,12 +138,12 @@ Semantic Color Tokens
 	--semantic-color-scrim-default: var(--primitive-color-black);
 
 	/* Effect */
+	--semantic-color-effect-default-drop-shadow: var(--primitive-color-black);
+	--semantic-color-effect-default-inner-shadow: var(--primitive-color-white);
 	--semantic-color-effect-home-grid-drop-shadow-dark: var(--primitive-color-black);
 	--semantic-color-effect-home-grid-drop-shadow-light: var(--primitive-color-white);
 	--semantic-color-effect-page-indicator-drop-shadow-dark: var(--primitive-color-black);
 	--semantic-color-effect-page-indicator-drop-shadow-light: var(--primitive-color-white);
 	--semantic-color-effect-status-bar-drop-shadow-dark: var(--primitive-color-black);
 	--semantic-color-effect-status-bar-drop-shadow-light: var(--primitive-color-white);
-	--semantic-color-effect-default-drop-shadow: var(--primitive-color-black);
-	--semantic-color-effect-default-inner-shadow: var(--primitive-color-white);
 }

--- a/packages/webos-m-tokens/css/radius-semantic.css
+++ b/packages/webos-m-tokens/css/radius-semantic.css
@@ -61,4 +61,5 @@ Semantic Radius Tokens
 	--semantic-radius-toast: var(--primitive-radius-18);
 	--semantic-radius-tooltip: var(--primitive-radius-18);
 	--semantic-radius-home-grid-indicator: var(--primitive-radius-18);
+	--semantic-radius-snackbar: var(--primitive-radius-18);
 }

--- a/packages/webos-m-tokens/css/radius-semantic.css
+++ b/packages/webos-m-tokens/css/radius-semantic.css
@@ -26,6 +26,7 @@ Semantic Radius Tokens
 	--semantic-radius-dialog-popup: var(--primitive-radius-36);
 	--semantic-radius-floating-window: var(--primitive-radius-12);
 	--semantic-radius-handle: var(--primitive-radius-999);
+	--semantic-radius-home-grid-indicator: var(--primitive-radius-18);
 	--semantic-radius-icon-grid: var(--primitive-radius-999);
 	--semantic-radius-list-l: var(--primitive-radius-36);
 	--semantic-radius-list-s: var(--primitive-radius-24);
@@ -51,6 +52,7 @@ Semantic Radius Tokens
 	--semantic-radius-selection-control-s: var(--primitive-radius-36);
 	--semantic-radius-side-sheet: var(--primitive-radius-48);
 	--semantic-radius-slider: var(--primitive-radius-999);
+	--semantic-radius-snackbar: var(--primitive-radius-18);
 	--semantic-radius-status-bar: var(--primitive-radius-999);
 	--semantic-radius-text-field: var(--primitive-radius-18);
 	--semantic-radius-thumbnail-xl: var(--primitive-radius-42);
@@ -60,6 +62,4 @@ Semantic Radius Tokens
 	--semantic-radius-thumbnail-xs: var(--primitive-radius-18);
 	--semantic-radius-toast: var(--primitive-radius-18);
 	--semantic-radius-tooltip: var(--primitive-radius-18);
-	--semantic-radius-home-grid-indicator: var(--primitive-radius-18);
-	--semantic-radius-snackbar: var(--primitive-radius-18);
 }

--- a/packages/webos-m-tokens/json/color-semantic-dark.json
+++ b/packages/webos-m-tokens/json/color-semantic-dark.json
@@ -101,7 +101,9 @@
                 "tab-active": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/active-red-55"},
                 "toast": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"},
                 "tooltip": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"},
-                "button-notification": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-35"}
+                "button-notification": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-35"},
+                "button-icon-focused": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
+                "snackbar": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"}
             },
             "stroke": {
                 "default-error": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/deep-orange-60"},
@@ -128,14 +130,14 @@
                 "default": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"}
             },
             "effect": {
-                "inner-shadow": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
-                "drop-shadow": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
                 "home-grid-drop-shadow-dark": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
                 "home-grid-drop-shadow-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                 "page-indicator-drop-shadow-dark": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
                 "page-indicator-drop-shadow-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                 "status-bar-drop-shadow-dark": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
-                "status-bar-drop-shadow-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"}
+                "status-bar-drop-shadow-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
+                "default-drop-shadow": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
+                "default-inner-shadow": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"}
             }
         }
     }

--- a/packages/webos-m-tokens/json/color-semantic-dark.json
+++ b/packages/webos-m-tokens/json/color-semantic-dark.json
@@ -67,8 +67,10 @@
                 "button-tertiary-disabled": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-30"},
                 "button-tint-pressed": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
                 "button-icon": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-30"},
+                "button-icon-focused": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                 "button-icon-selected": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-45"},
                 "button-icon-disabled": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-30"},
+                "button-notification": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-35"},
                 "chip": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-30"},
                 "chip-selected": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-40"},
                 "chip-disabled": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-30"},
@@ -90,6 +92,7 @@
                 "picker-date": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-45"},
                 "slider-tick-mark": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-55"},
                 "scroll-bar-handle": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-55"},
+                "snackbar": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"},
                 "status-bar": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"},
                 "selection-active": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-45"},
                 "selection-active-disabled": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/cobalt-blue-45"},
@@ -100,10 +103,7 @@
                 "selection-checkbox-inactive-disabled": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-5"},
                 "tab-active": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/active-red-55"},
                 "toast": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"},
-                "tooltip": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"},
-                "button-notification": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-35"},
-                "button-icon-focused": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
-                "snackbar": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"}
+                "tooltip": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/sand-gray-25"}
             },
             "stroke": {
                 "default-error": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/deep-orange-60"},
@@ -130,14 +130,14 @@
                 "default": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"}
             },
             "effect": {
+                "default-drop-shadow": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
+                "default-inner-shadow": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                 "home-grid-drop-shadow-dark": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
                 "home-grid-drop-shadow-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                 "page-indicator-drop-shadow-dark": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
                 "page-indicator-drop-shadow-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
                 "status-bar-drop-shadow-dark": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
-                "status-bar-drop-shadow-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"},
-                "default-drop-shadow": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/black"},
-                "default-inner-shadow": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"}
+                "status-bar-drop-shadow-light": {"$ref": "core-tokens/json/color-primitive.json#/primitive/color/white"}
             }
         }
     }

--- a/packages/webos-m-tokens/json/radius-semantic.json
+++ b/packages/webos-m-tokens/json/radius-semantic.json
@@ -49,7 +49,8 @@
             "thumbnail-xs": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
             "toast": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
             "tooltip": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
-            "home-grid-indicator": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"}
+            "home-grid-indicator": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
+            "snackbar": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"}
         }
     }
 }

--- a/packages/webos-m-tokens/json/radius-semantic.json
+++ b/packages/webos-m-tokens/json/radius-semantic.json
@@ -15,6 +15,7 @@
             "dialog-popup": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"},
             "floating-window": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-12"},
             "handle": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
+            "home-grid-indicator": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
             "icon-grid": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
             "list-l": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"},
             "list-s": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-24"},
@@ -40,6 +41,7 @@
             "selection-control-s": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-36"},
             "side-sheet": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-48"},
             "slider": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
+            "snackbar": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
             "status-bar": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-999"},
             "text-field": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
             "thumbnail-xl": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-42"},
@@ -48,9 +50,7 @@
             "thumbnail-s": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-24"},
             "thumbnail-xs": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
             "toast": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
-            "tooltip": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
-            "home-grid-indicator": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"},
-            "snackbar": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"}
+            "tooltip": {"$ref": "core-tokens/json/radius-primitive.json#/primitive/radius-18"}
         }
     }
 }


### PR DESCRIPTION
### Checklist

[//]: # (Contribution guide should be added)
* [x] A CHANGELOG entry is included  
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
This pull request updates the webOS M tokens to add new semantic color and radius tokens, and refactors some existing token names for clarity and consistency. The main changes include adding new tokens for focused button icons and snackbars, as well as renaming effect shadow tokens. The updates are reflected across Dart, CSS, and JSON files to keep all platforms in sync.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

**Token Additions and Renames**

* Renamed `semantic_color_effect_drop_shadow` and `semantic_color_effect_inner_shadow` to `semantic_color_effect_default_drop_shadow` and `semantic_color_effect_default_inner_shadow` throughout the Dart, CSS, and JSON files for consistency.
* Added new color tokens: `semantic_color_surface_button_icon_focused` and `semantic_color_surface_snackbar`, with corresponding entries in Dart, CSS, and JSON.
* Added new radius token: `semantic_radius_snackbar` in Dart, CSS, and JSON.

**Code and Token Consistency**

* Updated the `EffectBase` and `Effect` classes to use the new default shadow property names (`defaultDropShadow`, `defaultInnerShadow`).

**Cleanup and Redundancy Removal**

* Removed duplicate or misplaced entries for `homeGridIndicator` in the radius semantic Dart and JSON files to avoid redundancy.

These changes ensure that the design token system is more consistent and that new UI elements like focused button icons and snackbars are properly supported.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ATL-23995

### Comments
[//]: # (DCO should be here)
Enovaui-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)
